### PR TITLE
feat(api): GET /v1/users/{user_id}/stats — single-user engagement summary

### DIFF
--- a/API.md
+++ b/API.md
@@ -355,6 +355,30 @@ Materialised sessions grouped by inactivity gaps (default 30 min).
 
 ---
 
+### `GET /v1/users/{user_id}/stats` — Engagement summary
+
+Single-user engagement numbers for stats cards / dashboards. Mirrors one row of `/v1/pipeline/stats/engagement` so values stay consistent between the leaderboard and per-user views.
+
+`total_events`, `unique_tracks`, `diversity`, and `last_active` are computed over the **last 30 days** of events. `plays`, `skips`, and `skip_rate` come from the all-time `track_interactions` rollup.
+
+```json
+{
+  "user_id": "simon",
+  "window_days": 30,
+  "total_events": 1234,
+  "plays": 890,
+  "skips": 145,
+  "skip_rate": 0.163,
+  "unique_tracks": 412,
+  "diversity": 0.334,
+  "last_active": 1712000000
+}
+```
+
+`last_active` may be `null` if the user has no events in the 30-day window.
+
+---
+
 ## Tracks & Library
 
 ### `GET /v1/tracks` — List/search analyzed tracks

--- a/app/api/routes/users.py
+++ b/app/api/routes/users.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import time
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import func, select, update
@@ -460,6 +461,68 @@ async def get_user_sessions(
             }
             for s in rows
         ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Engagement stats
+# ---------------------------------------------------------------------------
+
+
+@router.get("/users/{user_id}/stats", summary="Per-user engagement stats")
+async def get_user_stats(
+    user_id: str,
+    session: AsyncSession = Depends(get_session),
+    _key: str = Depends(require_api_key),
+):
+    """Single-user engagement summary mirroring one row of /v1/pipeline/stats/engagement.
+
+    `total_events`, `unique_tracks`, and `last_active` are computed over the last
+    30 days of events. `plays` and `skips` come from the all-time
+    `track_interactions` rollup.
+    """
+    await _resolve_user(session, user_id, _key)
+
+    window_days = 30
+    cutoff = int(time.time()) - window_days * 86400
+
+    event_row = (
+        await session.execute(
+            select(
+                func.count(ListenEvent.id).label("total_events"),
+                func.count(func.distinct(ListenEvent.track_id)).label("unique_tracks"),
+                func.max(ListenEvent.timestamp).label("last_active"),
+            ).where(
+                ListenEvent.user_id == user_id,
+                ListenEvent.timestamp >= cutoff,
+            )
+        )
+    ).first()
+
+    inter_row = (
+        await session.execute(
+            select(
+                func.sum(TrackInteraction.play_count).label("plays"),
+                func.sum(TrackInteraction.skip_count).label("skips"),
+            ).where(TrackInteraction.user_id == user_id)
+        )
+    ).first()
+
+    total_events = event_row.total_events or 0
+    unique_tracks = event_row.unique_tracks or 0
+    plays = int(inter_row.plays or 0)
+    skips = int(inter_row.skips or 0)
+
+    return {
+        "user_id": user_id,
+        "window_days": window_days,
+        "total_events": total_events,
+        "plays": plays,
+        "skips": skips,
+        "skip_rate": round(skips / max(plays, 1), 3),
+        "unique_tracks": unique_tracks,
+        "diversity": round(unique_tracks / max(total_events, 1), 3),
+        "last_active": event_row.last_active,
     }
 
 

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -210,6 +210,24 @@ class TestUserSessions:
         assert resp.status_code == 404
 
 
+class TestUserStats:
+    async def test_get_stats(self, client: AsyncClient):
+        await seed_user_with_data()
+        resp = await client.get("/v1/users/testuser/stats")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["user_id"] == "testuser"
+        assert data["window_days"] == 30
+        # plays/skips come from track_interactions (all-time)
+        assert data["plays"] == 5
+        assert data["skips"] == 1
+        assert data["skip_rate"] == 0.2
+
+    async def test_get_stats_not_found(self, client: AsyncClient):
+        resp = await client.get("/v1/users/nonexistent/stats")
+        assert resp.status_code == 404
+
+
 class TestRecommendationHistory:
     async def test_history_empty(self, client: AsyncClient):
         await seed_user_with_data()


### PR DESCRIPTION
## Summary

- New `GET /v1/users/{user_id}/stats` returning the same numbers as one row of `/v1/pipeline/stats/engagement` (plays, skips, skip_rate, unique_tracks, diversity, last_active)
- 30-day window for event-derived fields, all-time `track_interactions` rollup for plays/skips
- API.md updated under the **Users** section

Refs #77 (leave open per request — feature request stays open until manually closed).

## Test plan

- [ ] CI: `tests/test_api_endpoints.py::TestUserStats` (happy path + 404)
- [ ] Manual smoke on prod: `curl https://.../v1/users/<known_user>/stats` returns expected shape