### PR TITLE
feat(api): client_ip + user_agent + source class on api_call_log (#81)

### DIFF
--- a/app/api/routes/api_calls.py
+++ b/app/api/routes/api_calls.py
@@ -1,4 +1,4 @@
-"""GrooveIQ – API call log routes (issue #79)."""
+"""GrooveIQ – API call log routes (issues #79, #81)."""
 
 from __future__ import annotations
 
@@ -16,13 +16,24 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+_VALID_SOURCES = {"browser", "mobile", "cli", "other"}
+
+
+def _validate_source(source: str | None) -> None:
+    if source and source not in _VALID_SOURCES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"source must be one of {sorted(_VALID_SOURCES)}",
+        )
+
+
 @router.get(
     "/users/{user_id}/api-calls",
     summary="List recent HTTP requests for one user",
     description=(
         "Paginated list of HTTP requests captured by the API logging middleware "
-        "for the given user. Use `path_contains` and `include_events=false` to "
-        "keep the table readable."
+        "for the given user. Use `path_contains`, `source`, and `include_events=false` "
+        "to keep the table readable."
     ),
 )
 async def list_user_api_calls(
@@ -34,10 +45,16 @@ async def list_user_api_calls(
     status: int | None = Query(None, ge=100, le=599, description="Exact status code"),
     include_events: bool = Query(True, description="Set false to hide POST /v1/events rows"),
     since_minutes: int | None = Query(None, ge=1, description="Only rows newer than this many minutes"),
+    source: str | None = Query(
+        None,
+        description="Filter by caller class derived from User-Agent: browser | mobile | cli | other",
+    ),
+    client_ip_contains: str | None = Query(None, description="Substring match on client IP"),
     session: AsyncSession = Depends(get_session),
     _key: str = Depends(require_api_key),
 ):
     check_user_access(_key, user_id)
+    _validate_source(source)
     since = int(time.time()) - since_minutes * 60 if since_minutes else None
     rows, total = await list_calls(
         session,
@@ -47,6 +64,8 @@ async def list_user_api_calls(
         status=status,
         include_events=include_events,
         since=since,
+        source=source,
+        client_ip_contains=client_ip_contains,
         limit=limit,
         offset=offset,
     )
@@ -90,10 +109,13 @@ async def list_all_api_calls(
     user_id: str | None = None,
     include_events: bool = True,
     since_minutes: int | None = Query(None, ge=1),
+    source: str | None = None,
+    client_ip_contains: str | None = None,
     session: AsyncSession = Depends(get_session),
     _key: str = Depends(require_api_key),
 ):
     require_admin(_key)
+    _validate_source(source)
     since = int(time.time()) - since_minutes * 60 if since_minutes else None
     rows, total = await list_calls(
         session,
@@ -103,6 +125,8 @@ async def list_all_api_calls(
         status=status,
         include_events=include_events,
         since=since,
+        source=source,
+        client_ip_contains=client_ip_contains,
         limit=limit,
         offset=offset,
     )

--- a/app/core/api_logging.py
+++ b/app/core/api_logging.py
@@ -18,6 +18,7 @@ from fastapi import Request, Response
 
 from app.core.config import settings
 from app.services.api_call_log import (
+    parse_client_ip,
     should_log_path,
     truncate_body,
     write_log,
@@ -81,6 +82,14 @@ async def api_call_logging_middleware(request: Request, call_next):
 
     t0 = time.monotonic()
 
+    # Caller identity (issue #81) — captured up-front so all three log paths
+    # below carry it: success, streaming, and exception.
+    client_ip = parse_client_ip(
+        request.headers.get("x-forwarded-for"),
+        request.client.host if request.client else None,
+    )
+    user_agent = request.headers.get("user-agent")
+
     # Buffer request body so downstream Pydantic parsing can re-read it.
     # Starlette caches on Request._body after first call to body() — FastAPI
     # uses the same accessor under the hood, so this is transparent.
@@ -120,6 +129,8 @@ async def api_call_logging_middleware(request: Request, call_next):
                 response_summary=None,
                 response_size_bytes=None,
                 error=error_msg,
+                client_ip=client_ip,
+                user_agent=user_agent,
             )
         )
         raise
@@ -146,6 +157,8 @@ async def api_call_logging_middleware(request: Request, call_next):
                 response_summary={"_skipped": "streaming response"},
                 response_size_bytes=None,
                 error=None,
+                client_ip=client_ip,
+                user_agent=user_agent,
             )
         )
         return response
@@ -196,6 +209,8 @@ async def api_call_logging_middleware(request: Request, call_next):
             response_summary=response_summary,
             response_size_bytes=len(response_bytes),
             error=None,
+            client_ip=client_ip,
+            user_agent=user_agent,
         )
     )
 

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -115,6 +115,10 @@ async def _apply_column_migrations(conn) -> None:
         ("track_features", "soundcloud_id", "VARCHAR(64)"),
         # Bitstream pre-flight validation marker (issue #32)
         ("track_features", "bitstream_validated_at", "INTEGER"),
+        # API call log: caller identity (issue #81)
+        ("api_call_logs", "client_ip", "VARCHAR(64)"),
+        ("api_call_logs", "user_agent", "VARCHAR(512)"),
+        ("api_call_logs", "source_class", "VARCHAR(16)"),
     ]
     for table, column, col_type in migrations:
         # Validate identifiers to prevent SQL injection via migration list.

--- a/app/models/db.py
+++ b/app/models/db.py
@@ -946,6 +946,13 @@ class ApiCallLog(Base):
     response_size_bytes = Column(Integer, nullable=True)
     error = Column(Text, nullable=True)
 
+    # Caller identity (issue #81) — UA-derived `source_class` distinguishes
+    # dashboard / mobile / CLI traffic; client_ip uses X-Forwarded-For when set
+    # (else request.client.host). Both nullable so existing rows remain valid.
+    client_ip = Column(String(64), nullable=True, index=True)
+    user_agent = Column(String(512), nullable=True)
+    source_class = Column(String(16), nullable=True, index=True)
+
     __table_args__ = (
         Index("idx_api_call_user_time", "user_id", "created_at"),
         Index("idx_api_call_path_time", "path", "created_at"),

--- a/app/services/api_call_log.py
+++ b/app/services/api_call_log.py
@@ -146,6 +146,81 @@ def _summarize_response(data: Any) -> Any:
 
 
 # ---------------------------------------------------------------------------
+# Caller identity (issue #81)
+# ---------------------------------------------------------------------------
+
+
+# Order matters: CLI patterns before browser, since some libraries (e.g.
+# python-requests) include "Mozilla" in their UA. Mobile is checked before
+# browser too because some mobile webviews still send a Mozilla UA.
+_CLI_PATTERNS = (
+    "curl/",
+    "wget/",
+    "httpie/",
+    "postmanruntime",
+    "go-http",
+    "python-requests",
+    "python-urllib",
+    "okhttp/",
+    "java/",
+    "axios/",
+    "node-fetch",
+    "got (https",
+    "insomnia",
+    "thunderclient",
+    "rest-client",
+)
+
+_MOBILE_PATTERNS = (
+    "iphone",
+    "ipad",
+    "ipod",
+    "android",
+    "darwin/",
+    "mobile",
+    "okhttp",  # also a mobile signal — already caught above as cli though
+    "cfnetwork",
+)
+
+_BROWSER_PATTERNS = (
+    "mozilla/",
+    "chrome/",
+    "safari/",
+    "firefox/",
+    "edge/",
+    "edg/",
+    "webkit/",
+    "trident/",
+)
+
+
+def classify_user_agent(ua: str | None) -> str:
+    """Classify a User-Agent string into browser / mobile / cli / other."""
+    if not ua or not ua.strip():
+        return "other"
+    ua_lower = ua.lower()
+    if any(p in ua_lower for p in _CLI_PATTERNS):
+        return "cli"
+    if any(p in ua_lower for p in _MOBILE_PATTERNS):
+        return "mobile"
+    if any(p in ua_lower for p in _BROWSER_PATTERNS):
+        return "browser"
+    return "other"
+
+
+def parse_client_ip(forwarded_for: str | None, fallback: str | None) -> str | None:
+    """Pick the client IP. ``X-Forwarded-For`` is a comma-separated chain
+    where the leftmost entry is the original client; trust it when set,
+    fall back to the direct peer address otherwise.
+    """
+    if forwarded_for:
+        first = forwarded_for.split(",", 1)[0].strip()
+        if first:
+            return first[:64]
+    return (fallback or "")[:64] or None
+
+
+# ---------------------------------------------------------------------------
 # Write
 # ---------------------------------------------------------------------------
 
@@ -164,6 +239,8 @@ async def write_log(
     response_summary: Any,
     response_size_bytes: int | None,
     error: str | None = None,
+    client_ip: str | None = None,
+    user_agent: str | None = None,
 ) -> None:
     """Persist one HTTP-call row.  Idempotent-safe: errors are swallowed."""
     if not settings.API_LOG_ENABLED:
@@ -184,6 +261,9 @@ async def write_log(
                 response_summary=response_summary,
                 response_size_bytes=response_size_bytes,
                 error=(error or "")[:4096] or None,
+                client_ip=client_ip,
+                user_agent=(user_agent or "")[:512] or None,
+                source_class=classify_user_agent(user_agent),
             )
             session.add(row)
             await session.commit()
@@ -205,6 +285,8 @@ async def list_calls(
     status: int | None = None,
     include_events: bool = True,
     since: int | None = None,
+    source: str | None = None,
+    client_ip_contains: str | None = None,
     limit: int = 50,
     offset: int = 0,
 ) -> tuple[list[dict[str, Any]], int]:
@@ -226,6 +308,10 @@ async def list_calls(
     if not include_events:
         conds.append(ApiCallLog.path != "/v1/events")
         conds.append(ApiCallLog.path != "/v1/events/batch")
+    if source:
+        conds.append(ApiCallLog.source_class == source)
+    if client_ip_contains:
+        conds.append(ApiCallLog.client_ip.contains(client_ip_contains))
 
     for c in conds:
         q = q.where(c)
@@ -281,6 +367,8 @@ def _row_to_summary(r: ApiCallLog) -> dict[str, Any]:
         "duration_ms": r.duration_ms,
         "is_error": r.status_code >= 400,
         "request_id": r.request_id,
+        "client_ip": r.client_ip,
+        "source_class": r.source_class,
     }
 
 
@@ -300,4 +388,7 @@ def _row_to_detail(r: ApiCallLog) -> dict[str, Any]:
         "response_size_bytes": r.response_size_bytes,
         "error": r.error,
         "request_id": r.request_id,
+        "client_ip": r.client_ip,
+        "user_agent": r.user_agent,
+        "source_class": r.source_class,
     }

--- a/app/static/css/pages.css
+++ b/app/static/css/pages.css
@@ -2490,6 +2490,38 @@
 .method-patch { color: #6B6B30; }
 .method-delete { color: var(--wine); border-color: rgba(156, 82, 109, 0.40); }
 
+.ud-apicalls-sourcecell {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    line-height: 1.2;
+}
+.ud-apicalls-source {
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    border: 1px solid var(--line);
+    width: fit-content;
+}
+.source-browser { color: #5b6e8a; border-color: rgba(91, 110, 138, 0.40); }
+.source-mobile { color: #6f5d8a; border-color: rgba(111, 93, 138, 0.40); }
+.source-cli { color: #6b6b30; border-color: rgba(107, 107, 48, 0.40); }
+.source-other { color: var(--ink-3); }
+.ud-apicalls-ip {
+    font-size: 10px;
+    line-height: 1.2;
+    word-break: break-all;
+}
+.ud-apicalls-ua-line {
+    flex-basis: 100%;
+    white-space: normal;
+    word-break: break-all;
+    line-height: 1.4;
+}
+
 .ud-apicalls-detail-row td {
     padding: 0 !important;
     background: var(--paper-2, rgba(0,0,0,0.02));

--- a/app/static/js/v2/monitor.js
+++ b/app/static/js/v2/monitor.js
@@ -3407,6 +3407,8 @@
             method: '',
             pathContains: '',
             status: '',
+            source: '',
+            clientIpContains: '',
             includeEvents: true,
             sinceMinutes: '',
             data: null,
@@ -3523,6 +3525,20 @@
                 ],
             }));
 
+            filterRow.appendChild(mkInput('Source', 'select', state.source, v => { state.source = v; state.offset = 0; load(); }, {
+                options: [
+                    { v: '', l: 'Any' },
+                    { v: 'browser', l: 'Browser' },
+                    { v: 'mobile', l: 'Mobile' },
+                    { v: 'cli', l: 'CLI / SDK' },
+                    { v: 'other', l: 'Other' },
+                ],
+            }));
+
+            filterRow.appendChild(mkInput('Client IP', 'text', state.clientIpContains, v => {
+                state.clientIpContains = v; state.offset = 0; load();
+            }, { placeholder: '192.168., 10.0., …' }));
+
             const evtWrap = document.createElement('label');
             evtWrap.className = 'ud-apicalls-filter ud-apicalls-checkbox';
             const cb = document.createElement('input');
@@ -3557,7 +3573,7 @@
             tbl.className = 'ud-table ud-apicalls-table';
             tbl.innerHTML = '<thead><tr>'
                 + '<th></th>'
-                + '<th>Time</th><th>Method</th><th>Path</th><th>Status</th><th>Duration</th>'
+                + '<th>Time</th><th>Method</th><th>Path</th><th>Status</th><th>Duration</th><th>Source</th>'
                 + '</tr></thead>';
             const tbody = document.createElement('tbody');
             items.forEach(it => {
@@ -3568,13 +3584,20 @@
                 const statusCls = it.status_code >= 500 ? 'sh-bad'
                     : it.status_code >= 400 ? 'sh-warn'
                         : it.status_code >= 300 ? '' : '';
+                const sourceCls = it.source_class || 'other';
+                const sourceLabel = sourceCls === 'cli' ? 'CLI' : sourceCls.charAt(0).toUpperCase() + sourceCls.slice(1);
+                const ip = it.client_ip || '—';
                 tr.innerHTML = '<td class="ud-apicalls-toggle mono">' + (state.expandedRowId === it.id ? '▾' : '▸') + '</td>'
                     + '<td class="mono">' + GIQ.fmt.esc(GIQ.fmt.timeAgo(it.created_at)) + '</td>'
                     + '<td class="mono"><span class="ud-apicalls-method method-' + it.method.toLowerCase() + '">'
                     + GIQ.fmt.esc(it.method) + '</span></td>'
-                    + '<td class="mono ud-truncate" style="max-width:380px">' + GIQ.fmt.esc(it.path) + '</td>'
+                    + '<td class="mono ud-truncate" style="max-width:340px">' + GIQ.fmt.esc(it.path) + '</td>'
                     + '<td class="mono ' + statusCls + '">' + Number(it.status_code) + '</td>'
-                    + '<td class="mono">' + Number(it.duration_ms) + 'ms</td>';
+                    + '<td class="mono">' + Number(it.duration_ms) + 'ms</td>'
+                    + '<td class="mono ud-apicalls-sourcecell">'
+                    + '<span class="ud-apicalls-source source-' + sourceCls + '">' + GIQ.fmt.esc(sourceLabel) + '</span>'
+                    + '<span class="ud-apicalls-ip muted">' + GIQ.fmt.esc(ip) + '</span>'
+                    + '</td>';
                 tr.addEventListener('click', (e) => {
                     e.stopPropagation();
                     toggleRow(it.id);
@@ -3585,7 +3608,7 @@
                     const detailTr = document.createElement('tr');
                     detailTr.className = 'ud-apicalls-detail-row';
                     const td = document.createElement('td');
-                    td.colSpan = 6;
+                    td.colSpan = 7;
                     td.appendChild(buildDetailPanel(it.id));
                     detailTr.appendChild(td);
                     tbody.appendChild(detailTr);
@@ -3653,6 +3676,9 @@
                 + '<div><span class="muted">Status:</span> ' + Number(detail.status_code) + '</div>'
                 + '<div><span class="muted">Duration:</span> ' + Number(detail.duration_ms) + 'ms</div>'
                 + '<div><span class="muted">Response size:</span> ' + (detail.response_size_bytes != null ? Number(detail.response_size_bytes).toLocaleString() + ' B' : '—') + '</div>'
+                + (detail.client_ip ? '<div><span class="muted">Client IP:</span> ' + GIQ.fmt.esc(detail.client_ip) + '</div>' : '')
+                + (detail.source_class ? '<div><span class="muted">Source:</span> ' + GIQ.fmt.esc(detail.source_class) + '</div>' : '')
+                + (detail.user_agent ? '<div class="ud-apicalls-ua-line"><span class="muted">User-Agent:</span> ' + GIQ.fmt.esc(detail.user_agent) + '</div>' : '')
                 + (detail.error ? '<div class="sh-bad"><span class="muted">Error:</span> ' + GIQ.fmt.esc(detail.error) + '</div>' : '');
             grid.appendChild(meta);
 
@@ -3694,6 +3720,8 @@
             if (state.status) params.set('status', state.status);
             if (!state.includeEvents) params.set('include_events', 'false');
             if (state.sinceMinutes) params.set('since_minutes', state.sinceMinutes);
+            if (state.source) params.set('source', state.source);
+            if (state.clientIpContains) params.set('client_ip_contains', state.clientIpContains);
             const url = '/v1/users/' + encodeURIComponent(userId) + '/api-calls?' + params.toString();
             GIQ.api.get(url).then(data => {
                 state.data = data;

--- a/migrations/014_add_api_call_log_caller_columns.py
+++ b/migrations/014_add_api_call_log_caller_columns.py
@@ -1,0 +1,103 @@
+"""
+Migration 014: Add caller-identity columns to api_call_logs.
+
+Issue #81 — distinguishes dashboard / mobile / CLI traffic in the per-user
+API call log by capturing client IP, full User-Agent, and a derived
+``source_class`` enum (``browser`` / ``mobile`` / ``cli`` / ``other``) at
+write time.
+
+Fresh databases get these columns automatically via
+``Base.metadata.create_all`` and ``_apply_column_migrations`` in
+``app/db/session.py``. This script is for operators who already ran
+migration 013 and want to upgrade an existing schema explicitly.
+
+Idempotent: SQLite ALTERs that fail (column already exists) are swallowed;
+Postgres uses ``ADD COLUMN IF NOT EXISTS``.
+
+Usage:
+    python migrations/014_add_api_call_log_caller_columns.py
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
+
+_SQLITE_STMTS = [
+    "ALTER TABLE api_call_logs ADD COLUMN client_ip VARCHAR(64)",
+    "ALTER TABLE api_call_logs ADD COLUMN user_agent VARCHAR(512)",
+    "ALTER TABLE api_call_logs ADD COLUMN source_class VARCHAR(16)",
+    "CREATE INDEX IF NOT EXISTS ix_api_call_logs_client_ip ON api_call_logs (client_ip)",
+    "CREATE INDEX IF NOT EXISTS ix_api_call_logs_source_class ON api_call_logs (source_class)",
+]
+
+
+_POSTGRES_STMTS = [
+    "ALTER TABLE api_call_logs ADD COLUMN IF NOT EXISTS client_ip VARCHAR(64)",
+    "ALTER TABLE api_call_logs ADD COLUMN IF NOT EXISTS user_agent VARCHAR(512)",
+    "ALTER TABLE api_call_logs ADD COLUMN IF NOT EXISTS source_class VARCHAR(16)",
+    "CREATE INDEX IF NOT EXISTS ix_api_call_logs_client_ip ON api_call_logs (client_ip)",
+    "CREATE INDEX IF NOT EXISTS ix_api_call_logs_source_class ON api_call_logs (source_class)",
+]
+
+
+def migrate_sqlite(db_path: str) -> None:
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    for stmt in _SQLITE_STMTS:
+        try:
+            cursor.execute(stmt)
+            print(f"  + {stmt[:80]}")
+        except sqlite3.OperationalError as exc:
+            # "duplicate column name" on ALTER, or "already exists" on CREATE INDEX — both fine.
+            print(f"  · {stmt[:80]}  ({exc})")
+    conn.commit()
+    conn.close()
+    print("\nMigration 014 complete.")
+
+
+def migrate_postgres(database_url: str) -> None:
+    try:
+        import psycopg2
+    except ImportError:
+        sys.exit("psycopg2 is required for PostgreSQL migrations: pip install psycopg2-binary")
+
+    url = database_url.replace("postgresql+asyncpg://", "postgresql://")
+    conn = psycopg2.connect(url)
+    conn.autocommit = True
+    cursor = conn.cursor()
+    for stmt in _POSTGRES_STMTS:
+        cursor.execute(stmt)
+        print(f"  + {stmt[:80]}")
+    conn.close()
+    print("\nMigration 014 complete.")
+
+
+def main() -> None:
+    database_url = os.environ.get("DATABASE_URL", "sqlite+aiosqlite:////data/grooveiq.db")
+    print(f"Migrating: {database_url}\n")
+
+    if "sqlite" in database_url:
+        db_path = database_url.split("///", 1)[-1]
+        if not Path(db_path).exists():
+            sys.exit(f"Database file not found: {db_path}")
+        migrate_sqlite(db_path)
+    elif "postgresql" in database_url:
+        migrate_postgres(database_url)
+    else:
+        sys.exit(f"Unsupported DATABASE_URL scheme: {database_url}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_api_call_log.py
+++ b/tests/test_api_call_log.py
@@ -27,7 +27,9 @@ from app.db.session import get_session
 from app.main import app
 from app.models.db import ApiCallLog, Base, User
 from app.services.api_call_log import (
+    classify_user_agent,
     list_calls,
+    parse_client_ip,
     purge_old,
     redact,
     should_log_path,
@@ -172,6 +174,62 @@ class TestShouldLogPath:
         assert should_log_path("/v1/events")
 
 
+class TestClassifyUserAgent:
+    def test_chrome_browser(self):
+        ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36"
+        assert classify_user_agent(ua) == "browser"
+
+    def test_firefox_browser(self):
+        assert classify_user_agent("Mozilla/5.0 (X11; Linux x86_64) Gecko/20100101 Firefox/130.0") == "browser"
+
+    def test_curl_cli(self):
+        assert classify_user_agent("curl/8.4.0") == "cli"
+
+    def test_python_requests_cli(self):
+        assert classify_user_agent("python-requests/2.31.0") == "cli"
+
+    def test_postman_cli(self):
+        assert classify_user_agent("PostmanRuntime/7.32.3") == "cli"
+
+    def test_iphone_mobile(self):
+        ua = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15"
+        # iPhone wins over generic Mozilla — mobile patterns checked first.
+        assert classify_user_agent(ua) == "mobile"
+
+    def test_android_mobile(self):
+        ua = "Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 Mobile Safari/537.36"
+        assert classify_user_agent(ua) == "mobile"
+
+    def test_empty_or_none(self):
+        assert classify_user_agent(None) == "other"
+        assert classify_user_agent("") == "other"
+        assert classify_user_agent("   ") == "other"
+
+    def test_unknown_falls_through(self):
+        assert classify_user_agent("CustomScraperBot/0.1") == "other"
+
+
+class TestParseClientIp:
+    def test_uses_xff_when_set(self):
+        assert parse_client_ip("203.0.113.5", "172.21.0.1") == "203.0.113.5"
+
+    def test_xff_takes_leftmost(self):
+        # Trusted proxy chain: original client comes first per RFC 7239 conventions.
+        assert parse_client_ip("203.0.113.5, 198.51.100.1", "172.21.0.1") == "203.0.113.5"
+
+    def test_falls_back_to_peer(self):
+        assert parse_client_ip(None, "172.21.0.1") == "172.21.0.1"
+        assert parse_client_ip("", "172.21.0.1") == "172.21.0.1"
+
+    def test_returns_none_when_both_missing(self):
+        assert parse_client_ip(None, None) is None
+        assert parse_client_ip("", "") is None
+
+    def test_caps_length(self):
+        # Pathological XFF (huge string) shouldn't blow past the column.
+        assert len(parse_client_ip("X" * 200, None)) <= 64
+
+
 # ---------------------------------------------------------------------------
 # Middleware integration tests
 # ---------------------------------------------------------------------------
@@ -256,6 +314,30 @@ class TestMiddlewarePersists:
         match = next(r for r in rows if r.path == "/v1/users/simon/profile")
         assert match.user_id == "simon"
 
+    async def test_captures_user_agent_and_classifies_source(self, client, monkeypatch):
+        monkeypatch.setattr(settings, "API_LOG_ENABLED", True)
+        await _seed_user("alice")
+        await client.get(
+            "/v1/users/alice/profile",
+            headers={"User-Agent": "curl/8.4.0", "X-Forwarded-For": "203.0.113.42"},
+        )
+        rows = await _wait_for_log_rows(min_count=1)
+        match = next(r for r in rows if r.path == "/v1/users/alice/profile")
+        assert match.user_agent == "curl/8.4.0"
+        assert match.source_class == "cli"
+        assert match.client_ip == "203.0.113.42"
+
+    async def test_browser_classification(self, client, monkeypatch):
+        monkeypatch.setattr(settings, "API_LOG_ENABLED", True)
+        await _seed_user("alice")
+        await client.get(
+            "/v1/users/alice/profile",
+            headers={"User-Agent": "Mozilla/5.0 Chrome/130.0.0.0 Safari/537.36"},
+        )
+        rows = await _wait_for_log_rows(min_count=1)
+        match = next(r for r in rows if r.path == "/v1/users/alice/profile")
+        assert match.source_class == "browser"
+
 
 # ---------------------------------------------------------------------------
 # Service-level: list_calls + purge_old
@@ -325,6 +407,30 @@ class TestListCalls:
             rows, total = await list_calls(s, limit=2, offset=0)
         assert total == 5
         assert len(rows) == 2
+
+    async def test_filter_by_source(self):
+        await _insert_log_row(source_class="browser", user_agent="Mozilla/5.0 Chrome/130.0")
+        await _insert_log_row(source_class="cli", user_agent="curl/8.4.0")
+        await _insert_log_row(source_class="cli", user_agent="python-requests/2.31.0")
+        async with _TestSession() as s:
+            rows, total = await list_calls(s, source="cli")
+        assert total == 2
+        assert all(r["source_class"] == "cli" for r in rows)
+
+    async def test_filter_by_client_ip_contains(self):
+        await _insert_log_row(client_ip="192.168.1.42", source_class="browser")
+        await _insert_log_row(client_ip="10.0.0.5", source_class="mobile")
+        async with _TestSession() as s:
+            rows, total = await list_calls(s, client_ip_contains="192.168.")
+        assert total == 1
+        assert rows[0]["client_ip"] == "192.168.1.42"
+
+    async def test_summary_includes_source_and_ip(self):
+        await _insert_log_row(client_ip="203.0.113.5", source_class="browser")
+        async with _TestSession() as s:
+            rows, _ = await list_calls(s)
+        assert rows[0]["client_ip"] == "203.0.113.5"
+        assert rows[0]["source_class"] == "browser"
 
 
 class TestPurgeOld:


### PR DESCRIPTION
## Summary

Follow-up to [#79](https://github.com/Sxx7/GrooveIQ/pull/80) — distinguishes dashboard / mobile / CLI traffic in the per-user API call log. On a self-hosted box behind a reverse proxy every request lands as \`172.21.0.1\` unless we parse \`X-Forwarded-For\`, so User-Agent ends up being the more reliable signal. \`source_class\` is derived from UA at write time.

Closes part of [#81](https://github.com/Sxx7/GrooveIQ/issues/81).

## What's in this change

- **Schema**: \`ApiCallLog\` gains \`client_ip\`, \`user_agent\`, \`source_class\` (all nullable, indexed). Auto-migrated; standalone migration [014_add_api_call_log_caller_columns.py](migrations/014_add_api_call_log_caller_columns.py) for explicit-schema operators.
- **Capture** ([app/core/api_logging.py](app/core/api_logging.py)): \`parse_client_ip()\` takes the leftmost \`X-Forwarded-For\` entry (RFC 7239), falls back to \`request.client.host\`. UA grabbed from header. Both passed to all three \`write_log\` call sites.
- **Classification** ([app/services/api_call_log.py](app/services/api_call_log.py)): CLI patterns (\`curl/\`, \`python-requests\`, \`okhttp/\`, \`postmanruntime\`, etc.) checked first — many of those send a Mozilla UA. Mobile patterns (\`iPhone\`, \`Android\`, \`Darwin/\`, \`Mobile\`) checked before browser so iOS Safari classifies as mobile. Browser falls through to anything Mozilla/WebKit-like. Empty / unrecognised → \`other\`.
- **Endpoints**: \`GET /v1/users/{id}/api-calls\` and admin \`GET /v1/api-calls\` gain \`?source=browser|mobile|cli|other\` and \`?client_ip_contains=\`. Invalid source returns 422.
- **Dashboard**: New "Source" dropdown + "Client IP" text input added to the filter row. New "Source" column on the table with a colour-coded badge above the IP. Detail panel adds Client IP / Source / full User-Agent rows.

## Test plan

- [x] \`pytest tests/\` — 315 passed (47 in test_api_call_log.py, was 28)
- [x] \`ruff check app/ tests/\` + \`ruff format --check\` — clean
- [x] Manual: hit \`/v1/users/User/profile\` with \`-A curl/8.4.0\` (→ \`source_class=cli\`), \`Mozilla/5.0 Chrome/130.0\` (→ \`browser\`), \`python-requests/2.31\` (→ \`cli\`), \`Mozilla/5.0 (iPhone) Mobile\` (→ \`mobile\`). Dashboard shows distinct Browser / Mobile / CLI badges.
- [x] Manual: \`?source=cli\` filter narrows to CLI-only rows; reset returns mixed set.
- [x] Manual: detail panel exposes full User-Agent string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)