### PR TITLE
fix(audio): project FAISS embedding from EffNet trunk, not classifier head

### DIFF
--- a/app/services/analysis_worker.py
+++ b/app/services/analysis_worker.py
@@ -94,7 +94,12 @@ _PATCH_HOP = 96  # non-overlapping patches
 # ---------------------------------------------------------------------------
 
 _EMBEDDING_DIM = 64
-_EFFNET_DIM = 400
+# Discogs-EffNet exposes two outputs: a 400-dim style classifier head
+# (`activations`) and a 1280-dim trunk feature vector (`embeddings`). We
+# project the trunk — the classifier head is sparse for tracks that don't
+# match any of the 400 styles, which left ~37% of the library with NULL
+# embeddings post-#42 (issue #83).
+_EFFNET_DIM = 1280
 _RNG = np.random.RandomState(seed=20240101)
 _PROJ_MATRIX = (_RNG.randn(_EFFNET_DIM, _EMBEDDING_DIM) / np.sqrt(_EMBEDDING_DIM)).astype(np.float32)
 
@@ -1079,16 +1084,21 @@ def _extract_ml(
         for name, arr in zip(output_names, all_outputs):
             logger.warning("EffNet output '%s': shape=%s", name, arr.shape)
 
-    # Find the 1280-dim embedding that classifier heads expect.
-    # Fall back to the first output for the embedding projection.
-    embeddings = all_outputs[0]
+    # Find the 1280-dim trunk output. Used both for the external classifier
+    # heads below and as the source of the FAISS embedding projection (issue
+    # #83 — `all_outputs[0]` is the 400-dim style classifier head and is
+    # sparse for off-genre tracks, producing degenerate zero-norm projections).
     head_embeddings = None
     for name, arr in zip(output_names, all_outputs):
         if arr.ndim == 2 and arr.shape[1] == 1280:
             head_embeddings = arr
             break
 
-    mean_embedding = np.mean(embeddings, axis=0)
+    # Defensive fallback: if the model variant doesn't expose a 1280-dim
+    # output, project from `all_outputs[0]` instead so we still produce
+    # *something*. Should never trigger with the current Discogs-EffNet ONNX.
+    embedding_source = head_embeddings if head_embeddings is not None else all_outputs[0]
+    mean_embedding = np.mean(embedding_source, axis=0)
 
     # --- Classifier heads (need 1280-dim embeddings) ---
     if head_embeddings is None:

--- a/app/services/audio_analysis.py
+++ b/app/services/audio_analysis.py
@@ -25,7 +25,7 @@ import os
 # Bump this whenever the analysis pipeline changes in a way that would
 # produce different feature values.  The scanner compares stored versions
 # against this constant to decide whether a track needs re-analysis.
-ANALYSIS_VERSION = "2.2"
+ANALYSIS_VERSION = "2.3"
 
 # Must match FAISS index dimension (faiss_index._EMBEDDING_DIM).
 EMBEDDING_DIM = 64


### PR DESCRIPTION
Fixes #83.

## Summary
- `_extract_ml` was picking `all_outputs[0]` (the 400-dim Discogs style classifier head) as the source for the FAISS embedding projection. It's sparse for off-genre tracks → mean collapses near zero → norm < 1e-8 → `_build_embedding` returns None → row stored as analyzed-but-no-embedding. On prod this hit ~37% of the library (32,010/87,048).
- Switch projection source to `head_embeddings` — the 1280-dim trunk that the danceability/valence/mood classifier heads already use. Grow `_PROJ_MATRIX` to (1280, 64) accordingly.
- Bump `ANALYSIS_VERSION` 2.2 → 2.3 so the next library scan re-analyzes existing rows. Old and new embeddings live in different projection subspaces, so a full rescan is required after deploy.

## Test plan
- [x] Re-ran the worker live on prod against the failing seed (`Catapult.ogg`) before the patch — reproduced `embedding is None`. Will re-run after deploy to confirm a non-None embedding.
- [ ] After redeploy + rescan: `SELECT COUNT(*) FROM track_features WHERE analyzed_at IS NOT NULL AND analysis_error IS NULL AND embedding IS NULL` ≈ 0.
- [ ] `POST /v1/radio/start` with the original failing seed returns 201 with a populated track list.
- [ ] FAISS effnet index size approaches `total_tracks - corrupt - too_short`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)