### PR TITLE
fix(api-call-log): surface PATCH /v1/users/{uid} rows under per-user view (#81)

### DIFF
--- a/app/services/api_call_log.py
+++ b/app/services/api_call_log.py
@@ -16,12 +16,12 @@ import logging
 import time
 from typing import Any
 
-from sqlalchemy import delete, func, select
+from sqlalchemy import delete, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.db.session import AsyncSessionLocal
-from app.models.db import ApiCallLog
+from app.models.db import ApiCallLog, User
 
 logger = logging.getLogger(__name__)
 
@@ -296,7 +296,24 @@ async def list_calls(
 
     conds = []
     if user_id:
-        conds.append(ApiCallLog.user_id == user_id)
+        # PATCH /v1/users/{uid} captures user_id=NULL because the route's path
+        # param is the numeric uid, not the user_id string. Resolve uid via a
+        # User lookup and OR-match path so those rows surface under the
+        # per-user view too. Issue #81 follow-up.
+        # The User model exposes `uid` as a property over the `id` column;
+        # the SQL column is `User.id`.
+        uid = (await session.execute(select(User.id).where(User.user_id == user_id))).scalar_one_or_none()
+        if uid is not None:
+            uid_path = f"/v1/users/{uid}"
+            conds.append(
+                or_(
+                    ApiCallLog.user_id == user_id,
+                    ApiCallLog.path == uid_path,
+                    ApiCallLog.path.like(f"{uid_path}/%"),
+                )
+            )
+        else:
+            conds.append(ApiCallLog.user_id == user_id)
     if method:
         conds.append(ApiCallLog.method == method.upper())
     if path_contains:

--- a/tests/test_api_call_log.py
+++ b/tests/test_api_call_log.py
@@ -432,6 +432,48 @@ class TestListCalls:
         assert rows[0]["client_ip"] == "203.0.113.5"
         assert rows[0]["source_class"] == "browser"
 
+    async def test_uid_path_rows_surface_under_user_filter(self):
+        """PATCH /v1/users/{uid} rows have empty user_id but still belong to
+        the user — list_calls(user_id="alice") must include them by resolving
+        alice's uid and OR-matching the numeric path."""
+        async with _TestSession() as s:
+            user = User(user_id="alice", display_name="Alice")
+            s.add(user)
+            await s.commit()
+            await s.refresh(user)
+            alice_uid = user.uid
+
+        # PATCH row written by middleware: user_id is empty because the route
+        # param was {uid} not {user_id}.
+        await _insert_log_row(
+            user_id=None,
+            method="PATCH",
+            path=f"/v1/users/{alice_uid}",
+            status_code=200,
+        )
+        # Plus a normal user_id-shaped row, for sanity.
+        await _insert_log_row(user_id="alice", path="/v1/users/alice/profile")
+        # And an unrelated user.
+        await _insert_log_row(user_id="bob", path="/v1/users/bob/profile")
+
+        async with _TestSession() as s:
+            rows, total = await list_calls(s, user_id="alice")
+        assert total == 2
+        paths = {r["path"] for r in rows}
+        assert f"/v1/users/{alice_uid}" in paths
+        assert "/v1/users/alice/profile" in paths
+
+    async def test_unknown_user_filter_falls_back_to_exact_match(self):
+        """When user_id doesn't resolve, behave like the old exact-match filter
+        (don't blow up, don't return everything)."""
+        await _insert_log_row(user_id="known", path="/v1/users/known/profile")
+        await _insert_log_row(user_id=None, path="/v1/users/99/profile")
+
+        async with _TestSession() as s:
+            rows, total = await list_calls(s, user_id="ghost")
+        assert total == 0
+        assert rows == []
+
 
 class TestPurgeOld:
     async def test_purges_old_rows(self):


### PR DESCRIPTION
## Summary

Smoke-test follow-up to [#82](https://github.com/Sxx7/GrooveIQ/pull/82). \`PATCH /v1/users/{uid}\` rows were being persisted (verified via direct SQL on prod) but invisible from \`GET /v1/users/{user_id}/api-calls\` because that route uses the numeric \`{uid}\` path param, not \`{user_id}\` — so the captured row had \`user_id=NULL\`.

Closes part of [#81](https://github.com/Sxx7/GrooveIQ/issues/81).

## Fix

[app/services/api_call_log.py](app/services/api_call_log.py): when \`list_calls(user_id="alice")\` is called, resolve alice → \`User.id\`, then OR-match:
\`\`\`
ApiCallLog.user_id == "alice"
  OR ApiCallLog.path == "/v1/users/<uid>"
  OR ApiCallLog.path LIKE "/v1/users/<uid>/%"
\`\`\`

Read-time (not write-time) because:
- middleware hot path stays free of an extra DB lookup per \`/v1/users/*\` request
- historical rows already in the table become visible without a backfill migration

If \`user_id\` doesn't resolve, falls back to plain exact-match — no rows leak from unrelated users.

## Test plan

- [x] \`pytest tests/\` — 317 passed (was 315; +2 new tests)
- [x] \`ruff check + format\` — clean
- [x] \`test_uid_path_rows_surface_under_user_filter\`: PATCH row with empty user_id but path \`/v1/users/<alice.uid>\` is included when filtering by \`user_id="alice"\`; unrelated user's rows aren't.
- [x] \`test_unknown_user_filter_falls_back_to_exact_match\`: filtering by a non-existent user_id returns no rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)