### PR TITLE
feat(security): enforce Navidrome-format user_id (#86)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -257,6 +257,13 @@ API_LOG_ENABLED=true                  # Master toggle for HTTP request logging
 # API_LOG_MAX_BODY_BYTES=4096         # Cap captured request/response body size
 # API_LOG_MAX_LIST_ITEMS=20           # For list-shaped responses, keep first N entries
 
+# ── user_id format enforcement (issue #86) ───────────────────────────────
+# Regex applied to every user_id GrooveIQ ingests (events, paths, bodies,
+# queries). Non-conforming values are rejected with 400. Default matches
+# Navidrome's xid (20 chars) + nanoid (21–22 chars) output. Override only
+# if you target a different media-server backend.
+# USER_ID_PATTERN=^[A-Za-z0-9]{20,22}$
+
 LASTFM_ENABLED=false          # Master toggle for per-user Last.fm features
 LASTFM_SCROBBLE_ENABLED=false # Forward listening history to Last.fm
 # LASTFM_REFRESH_HOURS=6       # How often to pull Last.fm profile data

--- a/app/api/routes/events.py
+++ b/app/api/routes/events.py
@@ -15,6 +15,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import check_user_access, check_user_event_rate, require_admin, require_api_key
+from app.core.user_id import validate_user_id
 from app.db.session import get_session
 from app.models.db import ListenEvent
 from app.models.schemas import EventBatch, EventCreate, EventResponse, ListenEventRead
@@ -69,6 +70,7 @@ async def ingest_event(
     session: AsyncSession = Depends(get_session),
     _key: str = Depends(require_api_key),
 ):
+    validate_user_id(event.user_id)
     check_user_access(_key, event.user_id)
     check_user_event_rate(event.user_id)
     result = await process_event(session, event)
@@ -104,6 +106,11 @@ async def ingest_event_batch(
     user_event_counts: dict[str, int] = {}
     for event in batch.events:
         user_event_counts[event.user_id] = user_event_counts.get(event.user_id, 0) + 1
+
+    # Issue #86: reject the whole batch if any event carries a malformed
+    # user_id, so partial inserts don't leak duplicate user rows.
+    for uid in user_event_counts:
+        validate_user_id(uid)
 
     # Check authorization and rate limit for each user with their full
     # batch count (not just 1 hit per unique user).

--- a/app/api/routes/lastfm.py
+++ b/app/api/routes/lastfm.py
@@ -23,6 +23,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.core.security import check_user_access, require_api_key
+from app.core.user_id import validate_user_id
 from app.db.session import get_session
 from app.models.db import ScrobbleQueue, User
 from app.models.schemas import (
@@ -45,6 +46,7 @@ def _require_lastfm_enabled() -> None:
 
 
 async def _resolve_user(session: AsyncSession, user_id: str, api_key: str = "anonymous") -> User:
+    validate_user_id(user_id)
     check_user_access(api_key, user_id)
     result = await session.execute(select(User).where(User.user_id == user_id))
     user = result.scalar_one_or_none()

--- a/app/api/routes/news.py
+++ b/app/api/routes/news.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, Path, Query
 
 from app.core.config import settings
 from app.core.security import check_user_access, require_api_key
+from app.core.user_id import validate_user_id
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -51,6 +52,7 @@ async def get_news(
     subreddit: str | None = Query(None, max_length=100, description="Filter to a specific subreddit"),
     _key: str = Depends(require_api_key),
 ):
+    validate_user_id(user_id)
     check_user_access(_key, user_id)
     if not settings.news_enabled:
         raise HTTPException(

--- a/app/api/routes/radio.py
+++ b/app/api/routes/radio.py
@@ -28,6 +28,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.core.security import check_user_access, require_admin, require_api_key
+from app.core.user_id import validate_user_id
 from app.db.session import get_session
 from app.models.db import ListenEvent, Playlist, TrackFeatures, User
 from app.models.schemas import (
@@ -67,6 +68,7 @@ async def start_radio(
     db: AsyncSession = Depends(get_session),
     _key: str = Depends(require_api_key),
 ):
+    validate_user_id(body.user_id)
     check_user_access(_key, body.user_id)
 
     # Verify user exists.
@@ -360,6 +362,7 @@ async def list_radio_sessions(
     _key: str = Depends(require_api_key),
 ):
     if user_id:
+        validate_user_id(user_id)
         check_user_access(_key, user_id)
     else:
         # Listing all sessions across users requires admin privileges.

--- a/app/api/routes/recommend.py
+++ b/app/api/routes/recommend.py
@@ -18,6 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.core.security import check_user_access, require_admin, require_api_key
+from app.core.user_id import validate_user_id
 from app.db.session import get_session
 from app.models.db import CoverArtCache, ListenEvent, TrackFeatures, TrackInteraction, User
 
@@ -81,6 +82,7 @@ async def get_recommendations(
         require_admin(_key)
 
     # Per-user authorization check.
+    validate_user_id(user_id)
     check_user_access(_key, user_id)
 
     # Verify user exists.
@@ -416,6 +418,7 @@ async def get_recommendation_history(
 ):
     from sqlalchemy import func as sa_func
 
+    validate_user_id(user_id)
     check_user_access(_key, user_id)
 
     # Verify user exists.
@@ -505,6 +508,7 @@ async def get_recommended_artists(
     session: AsyncSession = Depends(get_session),
     _key: str = Depends(require_api_key),
 ):
+    validate_user_id(user_id)
     check_user_access(_key, user_id)
 
     # --- Verify user & load taste profile ---

--- a/app/api/routes/users.py
+++ b/app/api/routes/users.py
@@ -10,6 +10,7 @@ from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import check_user_access, require_api_key
+from app.core.user_id import validate_user_id
 from app.db.session import get_session
 from app.models.db import ListenEvent, ListenSession, TrackFeatures, TrackInteraction, User
 from app.models.schemas import OnboardingRequest, OnboardingResponse, UserCreate, UserResponse, UserUpdate
@@ -30,9 +31,13 @@ async def _resolve_user(
 ) -> User:
     """Look up a user by user_id string.  Raises 404 if not found.
 
+    Issue #86: malformed user_ids (anything not matching ``USER_ID_PATTERN``)
+    raise 400 before any auth or DB work.
+
     When ``API_KEY_USERS`` is configured, also verifies that the
     requesting API key is authorised to access this user (raises 403).
     """
+    validate_user_id(user_id)
     check_user_access(api_key, user_id)
     result = await session.execute(select(User).where(User.user_id == user_id))
     user = result.scalar_one_or_none()
@@ -573,6 +578,7 @@ async def create_user(
     session: AsyncSession = Depends(get_session),
     _key: str = Depends(require_api_key),
 ):
+    validate_user_id(body.user_id)
     result = await session.execute(select(User).where(User.user_id == body.user_id))
     existing = result.scalar_one_or_none()
     if existing:
@@ -626,6 +632,8 @@ async def update_user(
 
     # Rename user_id with cascade.
     if body.user_id is not None and body.user_id != old_user_id:
+        # Issue #86: refuse to rename to a non-conforming user_id.
+        validate_user_id(body.user_id)
         # Check uniqueness of the new user_id.
         conflict = await session.execute(select(User.id).where(User.user_id == body.user_id))
         if conflict.scalar_one_or_none() is not None:

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -292,6 +292,15 @@ class Settings(BaseSettings):
     API_LOG_MAX_LIST_ITEMS: int = 20  # for list-shaped responses, keep first N entries
 
     # ------------------------------------------------------------------
+    # user_id format enforcement (issue #86)
+    # ------------------------------------------------------------------
+    # Plex media-server backend is no longer supported. Navidrome is the
+    # canonical source of identity. The default regex covers Navidrome's
+    # xid (20 chars) and nanoid (21–22 chars) output across versions.
+    # Override for non-Navidrome backends or stricter setups.
+    USER_ID_PATTERN: str = r"^[A-Za-z0-9]{20,22}$"
+
+    # ------------------------------------------------------------------
     # Personalized news feed (Reddit-sourced)
     # ------------------------------------------------------------------
     NEWS_ENABLED: bool = False

--- a/app/core/user_id.py
+++ b/app/core/user_id.py
@@ -1,0 +1,62 @@
+"""
+GrooveIQ – user_id format validation (issue #86).
+
+Single source of truth for "is this string a plausible user_id?". Default
+pattern matches Navidrome's identifier output across versions:
+
+  - xid    (Navidrome <0.50): 20 lowercase alphanumeric chars
+  - nanoid (Navidrome 0.50+): 21–22 mixed-case alphanumeric chars
+
+The pattern is configurable via ``USER_ID_PATTERN`` so non-Navidrome
+deployments (or future format changes) can override without a code change.
+"""
+
+from __future__ import annotations
+
+import re
+
+from fastapi import HTTPException
+
+from app.core.config import settings
+
+_compiled_pattern: tuple[str, re.Pattern[str]] | None = None
+
+
+def _get_pattern() -> re.Pattern[str]:
+    """Return the compiled USER_ID_PATTERN regex, recompiling if config changed.
+
+    Stored as a (source, compiled) tuple so `monkeypatch.setattr(settings,
+    "USER_ID_PATTERN", ...)` in tests is picked up without restart.
+    """
+    global _compiled_pattern
+    src = settings.USER_ID_PATTERN
+    if _compiled_pattern is None or _compiled_pattern[0] != src:
+        _compiled_pattern = (src, re.compile(src))
+    return _compiled_pattern[1]
+
+
+def is_valid_user_id(user_id: str | None) -> bool:
+    """Pure check, no exception. Use this in tests / conditionals."""
+    if not user_id:
+        return False
+    return bool(_get_pattern().fullmatch(user_id))
+
+
+def validate_user_id(user_id: str | None) -> str:
+    """Raise HTTPException(400) if `user_id` doesn't match the configured pattern.
+
+    Returns the input unchanged on success so callers can chain it as
+    ``user_id = validate_user_id(body.user_id)``.
+    """
+    if not is_valid_user_id(user_id):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Invalid user_id {user_id!r}: must match {settings.USER_ID_PATTERN}. "
+                "GrooveIQ requires the Navidrome user identifier."
+            ),
+        )
+    return user_id  # type: ignore[return-value]
+
+
+__all__ = ["is_valid_user_id", "validate_user_id"]

--- a/app/services/event_service.py
+++ b/app/services/event_service.py
@@ -17,6 +17,7 @@ from sqlalchemy import or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
+from app.core.user_id import validate_user_id
 from app.models.db import ListenEvent, TrackFeatures, User
 from app.models.schemas import EventCreate, EventResponse
 
@@ -212,7 +213,12 @@ async def process_event(
 
 
 async def _upsert_user(session: AsyncSession, user_id: str, now: int) -> None:
-    """Create user record on first event, update last_seen otherwise."""
+    """Create user record on first event, update last_seen otherwise.
+
+    Issue #86: reject malformed user_ids before any DB hit so typos and
+    dashboard test names can't auto-create User rows.
+    """
+    validate_user_id(user_id)
     result = await session.execute(select(User).where(User.user_id == user_id).limit(1))
     user = result.scalar_one_or_none()
     if user is None:

--- a/docs/API.md
+++ b/docs/API.md
@@ -4,6 +4,25 @@ All endpoints require `Authorization: Bearer <api_key>` unless noted otherwise.
 
 Interactive docs available at `/docs` when `ENABLE_DOCS=true` (development only).
 
+## `user_id` format (issue #86)
+
+Every endpoint that accepts a `user_id` — whether as a path param, query
+string, or request body field — enforces a regex on the value. Requests
+with a non-conforming `user_id` are rejected with **400 Bad Request**:
+
+```json
+{"detail": "Invalid user_id 'Simon': must match ^[A-Za-z0-9]{20,22}$. GrooveIQ requires the Navidrome user identifier."}
+```
+
+The default pattern (`^[A-Za-z0-9]{20,22}$`) covers Navidrome's identifier
+output across versions: `xid` (20 chars, pre-0.50) and `nanoid` (21–22
+chars, 0.50+). Override via the `USER_ID_PATTERN` env var if you target a
+different backend. Plex usernames (which were emails) are no longer
+supported — Navidrome is the canonical identity source.
+
+Clients should send the Navidrome user ID exactly as Navidrome surfaces
+it on `getUser.view`.
+
 ---
 
 ## Health & Dashboard
@@ -36,7 +55,7 @@ Ingest a single listen event.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `user_id` | string | Yes | Media server's user identifier |
+| `user_id` | string | Yes | Navidrome user identifier (must match `USER_ID_PATTERN`, see top of this doc) |
 | `track_id` | string | Yes | Media server's track identifier |
 | `event_type` | string | Yes | One of: `play_start`, `play_end`, `skip`, `pause`, `resume`, `like`, `dislike`, `rating`, `playlist_add`, `playlist_remove`, `queue_add`, `seek_back`, `seek_forward`, `repeat`, `volume_up`, `volume_down`, `reco_impression` |
 | `timestamp` | int | No | Unix epoch UTC (default: server time). Rejected if >24h old or >5min future |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,11 @@ _TEST_ENV = {
     "SPOTIZERR_PASSWORD": "",
     "LASTFM_API_KEY": "",
     "LASTFM_API_SECRET": "",
+    # Issue #86: relax user_id format enforcement for the existing test
+    # suite which seeds users with names like "alice" / "testuser".  The
+    # dedicated test_user_id.py module monkeypatches USER_ID_PATTERN to
+    # the production default to verify enforcement under real config.
+    "USER_ID_PATTERN": r"^[A-Za-z0-9_]+$",
 }
 
 for _k, _v in _TEST_ENV.items():

--- a/tests/test_user_id.py
+++ b/tests/test_user_id.py
@@ -1,0 +1,184 @@
+"""
+GrooveIQ – user_id format enforcement (issue #86).
+
+The default ``USER_ID_PATTERN`` matches Navidrome's identifier output
+(20–22 alphanumeric chars). Tests in this file pin the pattern to its
+production default explicitly, so they remain valid even if the global
+test override in ``conftest.py`` is relaxed for legacy fixtures.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.core.config import settings
+from app.core.user_id import is_valid_user_id, validate_user_id
+from app.db.session import get_session
+from app.main import app
+from app.models.db import Base, User
+
+_PROD_PATTERN = r"^[A-Za-z0-9]{20,22}$"
+
+TEST_DB_URL = "sqlite+aiosqlite:///:memory:"
+_test_engine = create_async_engine(TEST_DB_URL, connect_args={"check_same_thread": False})
+_TestSession = async_sessionmaker(_test_engine, expire_on_commit=False)
+
+
+async def override_get_session() -> AsyncGenerator[AsyncSession, None]:
+    async with _TestSession() as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def setup_db(monkeypatch):
+    # Pin the production-default pattern explicitly for the whole module.
+    monkeypatch.setattr(settings, "USER_ID_PATTERN", _PROD_PATTERN)
+    async with _test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    app.dependency_overrides[get_session] = override_get_session
+    yield
+    async with _test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def client():
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        headers={"Authorization": f"Bearer {settings.api_keys_list[0]}"} if settings.api_keys_list else {},
+    ) as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Pure validator
+# ---------------------------------------------------------------------------
+
+
+class TestIsValidUserId:
+    def test_navidrome_22char_accepted(self):
+        assert is_valid_user_id("RthAVUuiCHM0MVjwu0QFTb")  # 22 chars, real prod ID
+
+    def test_navidrome_20char_accepted(self):
+        assert is_valid_user_id("a1b2c3d4e5f6g7h8i9j0")  # legacy xid format
+
+    def test_navidrome_21char_accepted(self):
+        assert is_valid_user_id("a1b2c3d4e5f6g7h8i9j01")
+
+    def test_short_test_name_rejected(self):
+        assert not is_valid_user_id("Simon")
+        assert not is_valid_user_id("alice")
+        assert not is_valid_user_id("testuser")
+
+    def test_email_rejected(self):
+        assert not is_valid_user_id("39w3z2frwz@privaterelay.appleid.com")
+
+    def test_typos_rejected(self):
+        # Real strings that hit prod's api_call_logs as paths.
+        assert not is_valid_user_id("Simon27)7")
+        assert not is_valid_user_id("Simon2")
+        assert not is_valid_user_id("simon")  # lowercase, 5 chars
+
+    def test_empty_or_none_rejected(self):
+        assert not is_valid_user_id("")
+        assert not is_valid_user_id(None)
+        assert not is_valid_user_id("   ")
+
+    def test_too_long_rejected(self):
+        assert not is_valid_user_id("a" * 23)
+
+    def test_special_chars_rejected(self):
+        # 22 chars but contains a hyphen — Navidrome only emits [A-Za-z0-9].
+        assert not is_valid_user_id("a-b2c3d4e5f6g7h8i9j0kl")
+
+
+class TestValidateUserId:
+    def test_returns_input_on_valid(self):
+        assert validate_user_id("RthAVUuiCHM0MVjwu0QFTb") == "RthAVUuiCHM0MVjwu0QFTb"
+
+    def test_raises_400_on_invalid(self):
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc:
+            validate_user_id("Simon")
+        assert exc.value.status_code == 400
+        assert "Simon" in exc.value.detail
+        assert _PROD_PATTERN in exc.value.detail
+
+
+# ---------------------------------------------------------------------------
+# Endpoint integration
+# ---------------------------------------------------------------------------
+
+
+_GOOD = "RthAVUuiCHM0MVjwu0QFTb"  # 22-char Navidrome-shaped
+_BAD = "Simon"
+
+
+async def _seed(user_id: str = _GOOD) -> None:
+    async with _TestSession() as s:
+        s.add(User(user_id=user_id, display_name=user_id))
+        await s.commit()
+
+
+class TestEndpointRejectsBadUserId:
+    async def test_event_post_rejects_bad_user_id(self, client):
+        # POST /v1/events with malformed user_id should 400 BEFORE creating a user row.
+        resp = await client.post(
+            "/v1/events",
+            json={"user_id": _BAD, "track_id": "t1", "event_type": "play_start"},
+        )
+        assert resp.status_code == 400
+        assert "Simon" in resp.json()["detail"]
+        # And no User row should have been auto-created.
+        async with _TestSession() as s:
+            from sqlalchemy import select
+
+            count = (await s.execute(select(User).where(User.user_id == _BAD))).scalars().all()
+        assert count == []
+
+    async def test_event_post_accepts_good_user_id(self, client):
+        await _seed(_GOOD)
+        resp = await client.post(
+            "/v1/events",
+            json={"user_id": _GOOD, "track_id": "t1", "event_type": "play_start"},
+        )
+        # Either 202 (accepted) or 422 (track not found) — point is it's not a 400 from user_id.
+        assert resp.status_code != 400, f"Got 400 with body: {resp.text}"
+
+    async def test_get_user_profile_rejects_bad_user_id(self, client):
+        resp = await client.get(f"/v1/users/{_BAD}/profile")
+        assert resp.status_code == 400
+        assert "Simon" in resp.json()["detail"]
+
+    async def test_get_user_profile_returns_404_for_unknown_good_user_id(self, client):
+        # 22-char string that isn't in the DB — should 404, not 400.
+        resp = await client.get(f"/v1/users/{_GOOD}/profile")
+        assert resp.status_code == 404
+
+    async def test_post_users_rejects_bad_user_id(self, client):
+        resp = await client.post(
+            "/v1/users",
+            json={"user_id": _BAD, "display_name": "Simon"},
+        )
+        assert resp.status_code == 400
+
+    async def test_post_users_accepts_good_user_id(self, client):
+        resp = await client.post(
+            "/v1/users",
+            json={"user_id": _GOOD, "display_name": "Test"},
+        )
+        assert resp.status_code == 201
+        assert resp.json()["user_id"] == _GOOD


### PR DESCRIPTION
## Summary

Stops the duplicate-user accumulation traced on prod by enforcing a regex on every \`user_id\` GrooveIQ ingests. Plex backend support is being dropped — Navidrome is the canonical identity source going forward.

Closes [#86](https://github.com/Sxx7/GrooveIQ/issues/86).

## Behaviour

- Default pattern \`^[A-Za-z0-9]{20,22}$\` covers Navidrome's xid (20 chars, pre-0.50) and nanoid (21–22 chars, 0.50+).
- Configurable via \`USER_ID_PATTERN\` for non-Navidrome deployments.
- Rejects every typo that produced duplicates on prod: \`User\`, \`User27)7\`, \`User2\`, lowercase \`User\`, email \`[redacted-email]\`.
- Returns 400 with a human-readable detail naming the offending value and the pattern.

## Wired into

Every entry point that takes a \`user_id\` from outside:
- \`POST /v1/events\` / \`/v1/events/batch\` (route + \`_upsert_user\` defence-in-depth)
- \`_resolve_user\` in [users.py](app/api/routes/users.py) and [lastfm.py](app/api/routes/lastfm.py) — covers all \`GET /v1/users/{id}/*\`
- \`POST /v1/users\` (create) and \`PATCH /v1/users/{uid}\` body \`user_id\` (rename)
- \`POST /v1/radio/start\` and \`GET /v1/radio?user_id=\`
- \`GET /v1/recommend/{user_id}\` plus \`/history\` and \`/artists\`
- \`GET /v1/news/{user_id}\`

## Docs

- [docs/API.md](docs/API.md) — new section at the top documenting the constraint, with the 400 response body example. \`user_id\` field description in the events table calls out Navidrome.
- \`.env.example\` — \`USER_ID_PATTERN\` block.

## Test plan

- [x] \`pytest tests/\` — 334 passed (17 new in test_user_id.py)
- [x] \`ruff check + format\` — clean
- [x] Manual probe on local dev server with strict default:
  - \`POST /v1/users\` with \`User\` → 400 ✓ (no row created)
  - \`POST /v1/users\` with \`[redacted-user-id]\` → 201 ✓
  - \`POST /v1/events\` with \`User\` → 400 ✓
  - \`GET /v1/users/User/profile\` → 400 ✓ (was 404)
  - \`GET /v1/users/[redacted-user-id]/profile\` → 200 ✓
  - \`POST /v1/radio/start\` with \`User\` → 400 ✓

Existing prod traffic from the \`ampster\` client (which sends Navidrome IDs already) is unaffected. The dormant Plex-era \`uid=1\` will be deleted from prod after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)