### PR TITLE
feat(playlists): daily idempotency cache for POST /v1/playlists (#89)

### DIFF
--- a/app/api/routes/playlists.py
+++ b/app/api/routes/playlists.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -15,9 +15,11 @@ from app.models.schemas import (
     PlaylistResponse,
 )
 from app.services.playlist_service import (
+    compute_cache_key,
     delete_playlist,
     generate_playlist,
     get_playlist_with_tracks,
+    utc_day_bucket,
 )
 
 router = APIRouter()
@@ -27,13 +29,39 @@ router = APIRouter()
     "/playlists",
     response_model=PlaylistDetailResponse,
     status_code=status.HTTP_201_CREATED,
-    summary="Generate a new playlist",
+    summary="Generate a new playlist (idempotent within a UTC day)",
 )
 async def create_playlist(
     body: PlaylistCreate,
+    response: Response,
+    refresh: bool = Query(
+        False,
+        description="Bypass the daily idempotency cache and force a fresh generation.",
+    ),
     session: AsyncSession = Depends(get_session),
     _key: str = Depends(require_api_key),
 ):
+    # Daily idempotency: same caller + same params + same UTC day → return the
+    # already-generated playlist instead of creating a duplicate row. See #89.
+    key_hash = hash_key(_key)
+    cache_key = compute_cache_key(
+        created_by=key_hash,
+        strategy=body.strategy,
+        seed_track_id=body.seed_track_id,
+        params=body.params,
+        max_tracks=body.max_tracks,
+        bucket_date=utc_day_bucket(),
+    )
+
+    if not refresh:
+        hit = await session.execute(
+            select(Playlist.id).where(Playlist.cache_key == cache_key).order_by(Playlist.id.desc()).limit(1)
+        )
+        existing_id = hit.scalar_one_or_none()
+        if existing_id is not None:
+            response.status_code = status.HTTP_200_OK
+            return await get_playlist_with_tracks(session, existing_id)
+
     try:
         playlist = await generate_playlist(
             session=session,
@@ -43,8 +71,9 @@ async def create_playlist(
             params=body.params,
             max_tracks=body.max_tracks,
         )
-        # Record which API key created this playlist.
-        playlist.created_by = hash_key(_key)
+        # Record which API key created this playlist + the daily cache key.
+        playlist.created_by = key_hash
+        playlist.cache_key = cache_key
         await session.flush()
         # Reload with tracks for response
         detail = await get_playlist_with_tracks(session, playlist.id)

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -151,6 +151,8 @@ async def _apply_column_migrations(conn) -> None:
         ("api_call_logs", "client_ip", "VARCHAR(64)"),
         ("api_call_logs", "user_agent", "VARCHAR(512)"),
         ("api_call_logs", "source_class", "VARCHAR(16)"),
+        # Playlist daily idempotency cache (issue #89)
+        ("playlists", "cache_key", "VARCHAR(64)"),
     ]
     for table, column, col_type in migrations:
         # Validate identifiers to prevent SQL injection via migration list.
@@ -197,6 +199,12 @@ async def _apply_column_migrations(conn) -> None:
         )
     except Exception as e:
         logger.warning("Migration: could not create musicbrainz_track_id index: %s", e)
+
+    # Plain index on playlists.cache_key for the daily idempotency lookup (issue #89).
+    try:
+        await conn.exec_driver_sql("CREATE INDEX IF NOT EXISTS ix_playlists_cache_key ON playlists (cache_key)")
+    except Exception as e:
+        logger.warning("Migration: could not create playlists.cache_key index: %s", e)
 
     # Backfill: any pre-existing download_requests rows have source IS NULL
     # because the column was added without a default. Treat them as spotdl.

--- a/app/models/db.py
+++ b/app/models/db.py
@@ -318,6 +318,11 @@ class Playlist(Base):
     track_count = Column(Integer, nullable=False, default=0)
     total_duration = Column(Float, nullable=True)  # seconds
     created_by = Column(String(128), nullable=True)  # API key hash that created this playlist
+    # Daily idempotency key: sha256(owner|strategy|seed|params|max_tracks|UTC-day)[:32].
+    # Lets POST /v1/playlists return an existing row instead of generating a duplicate
+    # when the frontend re-issues the same request (e.g. tapping Play repeatedly).
+    # See issue #89.
+    cache_key = Column(String(64), nullable=True, index=True)
     created_at = Column(Integer, nullable=False, default=lambda: int(time.time()))
 
 

--- a/app/services/playlist_service.py
+++ b/app/services/playlist_service.py
@@ -14,8 +14,11 @@ when breaking ties or filling gaps.
 from __future__ import annotations
 
 import base64
+import hashlib
+import json
 import logging
 import time
+from datetime import UTC, datetime
 from typing import Any
 
 import numpy as np
@@ -25,6 +28,38 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.db import Playlist, PlaylistTrack, TrackFeatures
 
 logger = logging.getLogger(__name__)
+
+
+def utc_day_bucket(now: datetime | None = None) -> str:
+    """Current UTC day as ``YYYY-MM-DD`` — the time bucket for the playlist cache."""
+    return (now or datetime.now(UTC)).strftime("%Y-%m-%d")
+
+
+def compute_cache_key(
+    *,
+    created_by: str | None,
+    strategy: str,
+    seed_track_id: str | None,
+    params: dict[str, Any] | None,
+    max_tracks: int,
+    bucket_date: str,
+) -> str:
+    """Stable per-day idempotency key for a playlist generation request.
+
+    Excludes ``name`` so the frontend can vary the title without busting the
+    cache. ``params`` is canonicalised via ``sort_keys`` so dict ordering can't
+    produce a different hash for the same logical request. See issue #89.
+    """
+    payload = {
+        "owner": created_by or "",
+        "strategy": strategy,
+        "seed": seed_track_id or "",
+        "params": params or {},
+        "max_tracks": max_tracks,
+        "day": bucket_date,
+    }
+    blob = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(blob.encode()).hexdigest()[:32]
 
 
 # ---------------------------------------------------------------------------

--- a/migrations/015_add_playlist_cache_key.py
+++ b/migrations/015_add_playlist_cache_key.py
@@ -1,0 +1,98 @@
+"""
+Migration 015: Add daily idempotency cache_key column to playlists.
+
+Issue #89 — POST /v1/playlists creates a persistent row on every call. All
+strategies (text/mood/energy_curve/flow/key_compatible/path) are deterministic
+with the same params, so when a frontend re-issues the same request (Play
+button, daily refresh), the table accumulates duplicate playlists. The route
+now derives a per-(owner, strategy, params, UTC-day) cache_key and returns
+the existing row on a hit. This script adds the column + index for operators
+who already ran migration 014 and want to upgrade an existing schema.
+
+Fresh databases get this column automatically via Base.metadata.create_all
+and _apply_column_migrations in app/db/session.py.
+
+Idempotent: SQLite ALTERs that fail (column already exists) are swallowed;
+Postgres uses ADD COLUMN IF NOT EXISTS.
+
+Usage:
+    python migrations/015_add_playlist_cache_key.py
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
+
+_SQLITE_STMTS = [
+    "ALTER TABLE playlists ADD COLUMN cache_key VARCHAR(64)",
+    "CREATE INDEX IF NOT EXISTS ix_playlists_cache_key ON playlists (cache_key)",
+]
+
+
+_POSTGRES_STMTS = [
+    "ALTER TABLE playlists ADD COLUMN IF NOT EXISTS cache_key VARCHAR(64)",
+    "CREATE INDEX IF NOT EXISTS ix_playlists_cache_key ON playlists (cache_key)",
+]
+
+
+def migrate_sqlite(db_path: str) -> None:
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    for stmt in _SQLITE_STMTS:
+        try:
+            cursor.execute(stmt)
+            print(f"  + {stmt[:80]}")
+        except sqlite3.OperationalError as exc:
+            # "duplicate column name" on ALTER, or "already exists" on CREATE INDEX — both fine.
+            print(f"  · {stmt[:80]}  ({exc})")
+    conn.commit()
+    conn.close()
+    print("\nMigration 015 complete.")
+
+
+def migrate_postgres(database_url: str) -> None:
+    try:
+        import psycopg2
+    except ImportError:
+        sys.exit("psycopg2 is required for PostgreSQL migrations: pip install psycopg2-binary")
+
+    url = database_url.replace("postgresql+asyncpg://", "postgresql://")
+    conn = psycopg2.connect(url)
+    conn.autocommit = True
+    cursor = conn.cursor()
+    for stmt in _POSTGRES_STMTS:
+        cursor.execute(stmt)
+        print(f"  + {stmt[:80]}")
+    conn.close()
+    print("\nMigration 015 complete.")
+
+
+def main() -> None:
+    database_url = os.environ.get("DATABASE_URL", "sqlite+aiosqlite:////data/grooveiq.db")
+    print(f"Migrating: {database_url}\n")
+
+    if "sqlite" in database_url:
+        db_path = database_url.split("///", 1)[-1]
+        if not Path(db_path).exists():
+            sys.exit(f"Database file not found: {db_path}")
+        migrate_sqlite(db_path)
+    elif "postgresql" in database_url:
+        migrate_postgres(database_url)
+    else:
+        sys.exit(f"Unsupported DATABASE_URL scheme: {database_url}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_playlists_cache.py
+++ b/tests/test_playlists_cache.py
@@ -1,0 +1,277 @@
+"""
+GrooveIQ — Tests for the daily idempotency cache on POST /v1/playlists.
+
+Issue #89: same caller + same params + same UTC day must return the existing
+playlist (200) instead of creating a duplicate (201). ``?refresh=true`` must
+bypass the cache. Different params, different days, or different callers
+must each yield a fresh playlist.
+"""
+
+from __future__ import annotations
+
+import base64
+import time
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+
+import numpy as np
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.core.config import settings
+from app.db.session import get_session
+from app.main import app
+from app.models.db import Base, TrackFeatures
+from app.services.playlist_service import compute_cache_key, utc_day_bucket
+
+TEST_DB_URL = "sqlite+aiosqlite:///:memory:"
+_test_engine = create_async_engine(TEST_DB_URL, connect_args={"check_same_thread": False})
+_TestSession = async_sessionmaker(_test_engine, expire_on_commit=False)
+
+
+async def override_get_session() -> AsyncGenerator[AsyncSession, None]:
+    async with _TestSession() as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+
+
+def _make_embedding(seed: int) -> str:
+    rng = np.random.RandomState(seed)
+    vec = rng.randn(64).astype(np.float32)
+    vec /= np.linalg.norm(vec)
+    return base64.b64encode(vec.tobytes()).decode()
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def setup_db():
+    async with _test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    app.dependency_overrides[get_session] = override_get_session
+    yield
+    async with _test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def client():
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        headers={"Authorization": f"Bearer {settings.api_keys_list[0]}"} if settings.api_keys_list else {},
+    ) as c:
+        yield c
+
+
+async def _seed_tracks(n: int = 12) -> None:
+    """Seed enough analyzed tracks to satisfy the playlist generator's minimum."""
+    now = int(time.time())
+    async with _TestSession() as session:
+        for i in range(n):
+            session.add(
+                TrackFeatures(
+                    track_id=f"t{i:03d}",
+                    file_path=f"/music/t{i:03d}.mp3",
+                    title=f"Song {i}",
+                    artist=f"Artist {i % 3}",
+                    duration=180.0 + i,
+                    bpm=100.0 + i,
+                    energy=0.5 + (i % 5) / 10.0,
+                    valence=0.5,
+                    danceability=0.5,
+                    embedding=_make_embedding(i),
+                    mood_tags=[{"label": "happy", "confidence": 0.8 + (i % 2) * 0.1}],
+                    analyzed_at=now,
+                    analysis_version="1",
+                )
+            )
+        await session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for compute_cache_key
+# ---------------------------------------------------------------------------
+
+
+class TestCacheKey:
+    def test_identical_inputs_yield_identical_key(self):
+        kwargs = dict(
+            created_by="hash-a",
+            strategy="mood",
+            seed_track_id=None,
+            params={"mood": "happy"},
+            max_tracks=20,
+            bucket_date="2026-05-09",
+        )
+        assert compute_cache_key(**kwargs) == compute_cache_key(**kwargs)
+
+    def test_param_dict_order_does_not_matter(self):
+        a = compute_cache_key(
+            created_by="x",
+            strategy="text",
+            seed_track_id=None,
+            params={"prompt": "late night drive", "extra": 1},
+            max_tracks=25,
+            bucket_date="2026-05-09",
+        )
+        b = compute_cache_key(
+            created_by="x",
+            strategy="text",
+            seed_track_id=None,
+            params={"extra": 1, "prompt": "late night drive"},
+            max_tracks=25,
+            bucket_date="2026-05-09",
+        )
+        assert a == b
+
+    def test_different_owner_yields_different_key(self):
+        kw = dict(
+            strategy="mood",
+            seed_track_id=None,
+            params={"mood": "happy"},
+            max_tracks=20,
+            bucket_date="2026-05-09",
+        )
+        assert compute_cache_key(created_by="alice", **kw) != compute_cache_key(created_by="bob", **kw)
+
+    def test_different_day_yields_different_key(self):
+        kw = dict(
+            created_by="x",
+            strategy="mood",
+            seed_track_id=None,
+            params={"mood": "happy"},
+            max_tracks=20,
+        )
+        assert compute_cache_key(bucket_date="2026-05-09", **kw) != compute_cache_key(bucket_date="2026-05-10", **kw)
+
+    def test_different_max_tracks_yields_different_key(self):
+        kw = dict(
+            created_by="x",
+            strategy="mood",
+            seed_track_id=None,
+            params={"mood": "happy"},
+            bucket_date="2026-05-09",
+        )
+        assert compute_cache_key(max_tracks=20, **kw) != compute_cache_key(max_tracks=30, **kw)
+
+    def test_different_prompt_yields_different_key(self):
+        kw = dict(
+            created_by="x",
+            strategy="text",
+            seed_track_id=None,
+            max_tracks=20,
+            bucket_date="2026-05-09",
+        )
+        a = compute_cache_key(params={"prompt": "late night drive"}, **kw)
+        b = compute_cache_key(params={"prompt": "rainy morning coffee"}, **kw)
+        assert a != b
+
+    def test_utc_day_bucket_format(self):
+        # Format must be YYYY-MM-DD so it sorts naturally and is human-readable
+        d = utc_day_bucket(datetime(2026, 5, 9, 23, 59, tzinfo=UTC))
+        assert d == "2026-05-09"
+
+
+# ---------------------------------------------------------------------------
+# HTTP integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestPlaylistDailyCache:
+    async def test_first_call_returns_201_and_persists(self, client: AsyncClient):
+        await _seed_tracks()
+        body = {
+            "name": "Happy Vibes",
+            "strategy": "mood",
+            "params": {"mood": "happy"},
+            "max_tracks": 5,
+        }
+        resp = await client.post("/v1/playlists", json=body)
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert data["track_count"] >= 1
+
+    async def test_repeat_call_same_day_returns_200_with_same_id(self, client: AsyncClient):
+        await _seed_tracks()
+        body = {
+            "name": "Happy Vibes",
+            "strategy": "mood",
+            "params": {"mood": "happy"},
+            "max_tracks": 5,
+        }
+        first = await client.post("/v1/playlists", json=body)
+        assert first.status_code == 201
+        first_id = first.json()["id"]
+
+        second = await client.post("/v1/playlists", json=body)
+        assert second.status_code == 200, "second call should be a cache hit"
+        assert second.json()["id"] == first_id
+
+        # Even when the frontend changes the visible name, cache key is unchanged.
+        third = await client.post("/v1/playlists", json={**body, "name": "Different Title"})
+        assert third.status_code == 200
+        assert third.json()["id"] == first_id
+
+    async def test_refresh_query_param_bypasses_cache(self, client: AsyncClient):
+        await _seed_tracks()
+        body = {
+            "name": "Happy Vibes",
+            "strategy": "mood",
+            "params": {"mood": "happy"},
+            "max_tracks": 5,
+        }
+        first = await client.post("/v1/playlists", json=body)
+        assert first.status_code == 201
+        first_id = first.json()["id"]
+
+        forced = await client.post("/v1/playlists?refresh=true", json=body)
+        assert forced.status_code == 201, "refresh=true must regenerate"
+        assert forced.json()["id"] != first_id
+
+    async def test_different_params_yield_separate_playlists(self, client: AsyncClient):
+        await _seed_tracks()
+        a = await client.post(
+            "/v1/playlists",
+            json={"name": "A", "strategy": "mood", "params": {"mood": "happy"}, "max_tracks": 5},
+        )
+        b = await client.post(
+            "/v1/playlists",
+            json={"name": "B", "strategy": "mood", "params": {"mood": "happy"}, "max_tracks": 7},
+        )
+        assert a.status_code == 201
+        assert b.status_code == 201
+        assert a.json()["id"] != b.json()["id"]
+
+    async def test_pre_migration_rows_are_not_returned(self, client: AsyncClient):
+        """A playlist with cache_key NULL (pre-migration) must not be served as a hit
+        for a fresh request — the lookup filters on cache_key equality, not on
+        recreating the request."""
+        await _seed_tracks()
+        # Create a row directly with no cache_key, mimicking a pre-migration playlist.
+        from app.models.db import Playlist
+
+        async with _TestSession() as s:
+            old = Playlist(
+                name="Old Mix",
+                strategy="mood",
+                params={"mood": "happy"},
+                track_count=0,
+                total_duration=0.0,
+                created_at=int(time.time()),
+                cache_key=None,
+            )
+            s.add(old)
+            await s.commit()
+            old_id = old.id
+
+        resp = await client.post(
+            "/v1/playlists",
+            json={"name": "Happy Vibes", "strategy": "mood", "params": {"mood": "happy"}, "max_tracks": 5},
+        )
+        assert resp.status_code == 201, "should generate a new row, not return the NULL-cache-key one"
+        assert resp.json()["id"] != old_id


### PR DESCRIPTION
Closes #89.

## Summary

POST /v1/playlists creates a persistent row on every call. All current strategies (`text`, `mood`, `energy_curve`, `flow`, `key_compatible`, `path`) are deterministic with the same params, so a "Play" button hitting the endpoint repeatedly accumulates duplicate playlists in the DB.

This adds a per-(owner, strategy, params, max_tracks, UTC-day) idempotency cache:
- Same caller + same params + same day → returns existing playlist (**200**)
- New params / new day / different caller → fresh playlist (**201**)
- `?refresh=true` → force regenerate (**201**)

## Changes

- `app/models/db.py` — `Playlist.cache_key VARCHAR(64), nullable, indexed`
- `app/db/session.py` — column auto-applied via `_apply_column_migrations`; index created at startup
- `migrations/015_add_playlist_cache_key.py` — explicit operator script (mirrors 014 pattern, SQLite + Postgres)
- `app/services/playlist_service.py` — `compute_cache_key()` + `utc_day_bucket()` helpers
- `app/api/routes/playlists.py` — wrap `generate_playlist` with lookup; add `refresh: bool` query param
- `tests/test_playlists_cache.py` — 7 unit tests for the helper + 5 HTTP integration tests

`name` is intentionally excluded from the cache key so the frontend can vary the visible title without busting the cache. Pre-migration rows have `cache_key IS NULL` and are never returned by the lookup, so cutover is clean.

## Test plan
- [ ] CI green (lint, format, pytest, image build)
- [ ] After merge, deploy to local test server and verify with two back-to-back identical POSTs that the second returns 200 with the same `id`
- [ ] Verify `?refresh=true` returns 201 with a different `id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)