### PR TITLE
fix(clap): repair text-strategy SyntaxError + auto-install ONNX models (#91)

### DIFF
--- a/API.md
+++ b/API.md
@@ -1110,7 +1110,7 @@ UTC day, or a different API key all produce a fresh playlist (`201`).
 | `energy_curve` | `params.curve` | Match target energy profile (`ramp_up`, `cool_down`, `ramp_up_cool_down`, `steady_high`, `steady_low`) |
 | `key_compatible` | `seed_track_id` | Camelot wheel harmonic chaining |
 | `path` | `seed_track_id` + `params.target_track_id` | **Song Path** — sonic bridge between two tracks. Slerp-interpolates between their 64-dim audio embeddings and picks the nearest unused library track at each waypoint. Both IDs must exist in `track_features` and have an `embedding`. |
-| `text` | `params.prompt` | **CLAP Text Prompt** — encodes the prompt via the CLAP text tower and ranks tracks by cosine similarity in joint embedding space. Requires `CLAP_ENABLED=true` and at least some tracks with `clap_embedding` populated. Fails with `503` otherwise. |
+| `text` | `params.prompt` | **CLAP Text Prompt** — encodes the prompt via the CLAP text tower and ranks tracks by cosine similarity in joint embedding space. Requires `CLAP_ENABLED=true`; ONNX weights are auto-downloaded on first server start (~395 MB, see [README § Optional integrations](README.md#optional-integrations)). Returns `503` until at least some tracks have `clap_embedding` populated — the audio backfill runs as part of the next analysis tick. |
 
 **Example — Song Path**
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ All settings via environment variables or `.env` file. See [`.env.example`](.env
 | Charts | `CHARTS_ENABLED=true`, `LASTFM_API_KEY` |
 | News feed | `NEWS_ENABLED=true` (optional: `NEWS_INTERVAL_MINUTES`, `NEWS_DEFAULT_SUBREDDITS`) |
 | AcousticBrainz lookup | `AB_LOOKUP_URL`, `AB_LOOKUP_ENABLED=true` (separate container) |
+| CLAP text-to-music search | `CLAP_ENABLED=true` (~395 MB ONNX models auto-download on first start; persisted in the `grooveiq_data` volume) |
 
 ## Connecting your music app
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -137,11 +137,13 @@ class Settings(BaseSettings):
     # search ("melancholic rainy-night jazz"), text-seeded playlists/radio,
     # and text filters on recommendations.
     #
-    # Operators must provide two ONNX files: an audio encoder (48 kHz mono
-    # audio → 512-dim vector) and a text encoder (tokenised prompt →
-    # 512-dim vector). The recommended model is LAION-CLAP's music variant
-    # (`music_audioset_epoch_15_esc_90.14`) exported via the
-    # `laion-clap` repo's `export_onnx.py` utility.
+    # Models are auto-downloaded on first start from the `Xenova/larger_clap_
+    # music_and_speech` Hugging Face repo (pre-exported ONNX of LAION-CLAP's
+    # `larger_clap_music_and_speech` variant). Total ~395 MB on first start,
+    # cached in the named `grooveiq_data` volume so subsequent restarts are
+    # instant. To use a different variant, override the three URL settings
+    # below; to skip the download (air-gapped install), pre-place the files
+    # in CLAP_MODEL_DIR before starting.
     # ------------------------------------------------------------------
     CLAP_ENABLED: bool = False
     CLAP_MODEL_DIR: str = "/data/models/clap"  # where clap_audio.onnx, clap_text.onnx, tokenizer.json live
@@ -151,6 +153,17 @@ class Settings(BaseSettings):
     CLAP_EMBEDDING_DIM: int = 512
     CLAP_AUDIO_SR: int = 48000  # LAION-CLAP expects 48 kHz mono
     CLAP_AUDIO_CLIP_SECONDS: float = 10.0  # length of central slice fed to the audio encoder
+
+    # Auto-download URLs (issue #91). fp16 weights — half the size of fp32
+    # with negligible quality loss for retrieval. Each file lands in
+    # CLAP_MODEL_DIR under the corresponding *_FILE name above.
+    CLAP_TEXT_MODEL_URL: str = (
+        "https://huggingface.co/Xenova/larger_clap_music_and_speech/resolve/main/onnx/text_model_fp16.onnx"
+    )
+    CLAP_AUDIO_MODEL_URL: str = (
+        "https://huggingface.co/Xenova/larger_clap_music_and_speech/resolve/main/onnx/audio_model_fp16.onnx"
+    )
+    CLAP_TOKENIZER_URL: str = "https://huggingface.co/Xenova/larger_clap_music_and_speech/resolve/main/tokenizer.json"
 
     # Supported audio extensions (comma-separated)
     AUDIO_EXTENSIONS: str = ".mp3,.flac,.ogg,.m4a,.wav,.aac,.opus,.wv"

--- a/app/main.py
+++ b/app/main.py
@@ -52,6 +52,17 @@ async def lifespan(app: FastAPI):
     logger.info("GrooveIQ starting up...")
     await init_db()
 
+    # Auto-install CLAP ONNX models if enabled and missing (issue #91).
+    # Non-blocking conceptually: download failures log a warning but don't
+    # crash startup; the text-strategy playlist endpoint will surface a
+    # clean 503 if the files are still absent at request time.
+    try:
+        from app.services.clap_setup import ensure_clap_models
+
+        await ensure_clap_models()
+    except Exception as e:
+        logger.warning(f"CLAP model auto-install failed on startup: {e}")
+
     # Load algorithm config from DB (seeds defaults on first run).
     try:
         from app.services.algorithm_config import load_active_config

--- a/app/services/clap_setup.py
+++ b/app/services/clap_setup.py
@@ -24,9 +24,9 @@ import asyncio
 import logging
 import os
 import tempfile
-import urllib.error
-import urllib.request
 from pathlib import Path
+
+import httpx
 
 from app.core.config import settings
 
@@ -68,21 +68,22 @@ def _download_one(url: str, dest: Path, min_size: int, label: str) -> None:
     tmp = Path(tmp_path)
 
     try:
-        # 30s connect/read timeout; HF is fast but we don't want to hang
-        # startup forever if the network is wedged.
-        req = urllib.request.Request(url, headers={"User-Agent": "grooveiq/clap-setup"})
-        # URL is gated to https:// at the top of this function, so urllib's
-        # file:// scheme can never be reached by a misconfigured setting.
-        with urllib.request.urlopen(req, timeout=30) as resp:  # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
+        # httpx (already a project dep) only speaks http/https — file:// is
+        # not reachable, which sidesteps the urllib.urlopen surface area.
+        # Long timeout for large model files; HF is fast but a 250 MB read
+        # over a slow link can plausibly take a couple of minutes.
+        timeout = httpx.Timeout(connect=30.0, read=300.0, write=30.0, pool=30.0)
+        headers = {"User-Agent": "grooveiq/clap-setup"}
+        with (
+            httpx.Client(follow_redirects=True, timeout=timeout, headers=headers) as client,
+            client.stream("GET", url) as resp,
+        ):
+            resp.raise_for_status()
             total = int(resp.headers.get("Content-Length", "0"))
             written = 0
-            chunk = 1024 * 256  # 256 KiB
             next_log = 50 * 1024 * 1024  # log every 50 MB
             with tmp.open("wb") as f:
-                while True:
-                    buf = resp.read(chunk)
-                    if not buf:
-                        break
+                for buf in resp.iter_bytes(chunk_size=1024 * 256):
                     f.write(buf)
                     written += len(buf)
                     if written >= next_log:
@@ -143,7 +144,7 @@ def _ensure_clap_models_sync() -> None:
     for label, dest, url, min_size in missing:
         try:
             _download_one(url, dest, min_size, label)
-        except (urllib.error.URLError, OSError, RuntimeError, ValueError) as e:
+        except (httpx.HTTPError, OSError, RuntimeError, ValueError) as e:
             logger.warning(
                 "CLAP setup: failed to download %s from %s: %s — text strategy will return 503 until this resolves",
                 label,

--- a/app/services/clap_setup.py
+++ b/app/services/clap_setup.py
@@ -53,6 +53,13 @@ def _download_one(url: str, dest: Path, min_size: int, label: str) -> None:
     atomic — half-written files never appear at the final path even if
     the process is killed mid-download.
     """
+    # Defence-in-depth: settings come from a trusted operator-controlled
+    # .env, but reject anything other than https:// to make it impossible
+    # for an mis-configured URL to read local files via urllib's file://
+    # scheme support.
+    if not url.startswith("https://"):
+        raise ValueError(f"CLAP setup: refusing to fetch {label} from non-https URL: {url!r}")
+
     dest.parent.mkdir(parents=True, exist_ok=True)
     logger.info("CLAP setup: downloading %s from %s", label, url)
 
@@ -64,6 +71,8 @@ def _download_one(url: str, dest: Path, min_size: int, label: str) -> None:
         # 30s connect/read timeout; HF is fast but we don't want to hang
         # startup forever if the network is wedged.
         req = urllib.request.Request(url, headers={"User-Agent": "grooveiq/clap-setup"})
+        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
+        # — URL is restricted to https:// at the top of this function, so file:// reads are not reachable.
         with urllib.request.urlopen(req, timeout=30) as resp:
             total = int(resp.headers.get("Content-Length", "0"))
             written = 0
@@ -134,7 +143,7 @@ def _ensure_clap_models_sync() -> None:
     for label, dest, url, min_size in missing:
         try:
             _download_one(url, dest, min_size, label)
-        except (urllib.error.URLError, OSError, RuntimeError) as e:
+        except (urllib.error.URLError, OSError, RuntimeError, ValueError) as e:
             logger.warning(
                 "CLAP setup: failed to download %s from %s: %s — text strategy will return 503 until this resolves",
                 label,

--- a/app/services/clap_setup.py
+++ b/app/services/clap_setup.py
@@ -71,9 +71,9 @@ def _download_one(url: str, dest: Path, min_size: int, label: str) -> None:
         # 30s connect/read timeout; HF is fast but we don't want to hang
         # startup forever if the network is wedged.
         req = urllib.request.Request(url, headers={"User-Agent": "grooveiq/clap-setup"})
-        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
-        # — URL is restricted to https:// at the top of this function, so file:// reads are not reachable.
-        with urllib.request.urlopen(req, timeout=30) as resp:
+        # URL is gated to https:// at the top of this function, so urllib's
+        # file:// scheme can never be reached by a misconfigured setting.
+        with urllib.request.urlopen(req, timeout=30) as resp:  # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
             total = int(resp.headers.get("Content-Length", "0"))
             written = 0
             chunk = 1024 * 256  # 256 KiB

--- a/app/services/clap_setup.py
+++ b/app/services/clap_setup.py
@@ -1,0 +1,150 @@
+"""
+GrooveIQ — CLAP model auto-installer (issue #91).
+
+On startup, if ``CLAP_ENABLED=true`` and the three required files aren't
+already present in ``CLAP_MODEL_DIR``, fetch them from the Hugging Face
+URLs configured in ``settings``:
+
+    clap_text.onnx       <- CLAP_TEXT_MODEL_URL
+    clap_audio.onnx      <- CLAP_AUDIO_MODEL_URL
+    clap_tokenizer.json  <- CLAP_TOKENIZER_URL
+
+Defaults point to ``Xenova/larger_clap_music_and_speech`` (fp16, ~395 MB
+total). Files persist in the ``grooveiq_data`` named volume so subsequent
+starts are no-ops.
+
+Failures are non-fatal: a warning is logged and startup continues. The
+text-strategy playlist endpoint will then surface a clean 503 instead of
+crashing the whole API.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Minimum plausible byte size for each file. Catches partial downloads,
+# 404 HTML pages saved as .onnx, etc. Sizes are based on Xenova fp16
+# weights with ~30% slack to tolerate variant swaps.
+_MIN_SIZES = {
+    "text": 100 * 1024 * 1024,  # text_model_fp16.onnx is ~251 MB
+    "audio": 50 * 1024 * 1024,  # audio_model_fp16.onnx is ~143 MB
+    "tokenizer": 1 * 1024 * 1024,  # tokenizer.json is ~2 MB
+}
+
+
+def _file_ok(path: Path, min_size: int) -> bool:
+    return path.is_file() and path.stat().st_size >= min_size
+
+
+def _download_one(url: str, dest: Path, min_size: int, label: str) -> None:
+    """Download to a temp file in the same dir, then atomic rename.
+
+    Same-dir temp keeps it on the same filesystem so ``os.replace`` is
+    atomic — half-written files never appear at the final path even if
+    the process is killed mid-download.
+    """
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    logger.info("CLAP setup: downloading %s from %s", label, url)
+
+    fd, tmp_path = tempfile.mkstemp(prefix=f".{dest.name}.", dir=str(dest.parent))
+    os.close(fd)
+    tmp = Path(tmp_path)
+
+    try:
+        # 30s connect/read timeout; HF is fast but we don't want to hang
+        # startup forever if the network is wedged.
+        req = urllib.request.Request(url, headers={"User-Agent": "grooveiq/clap-setup"})
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            total = int(resp.headers.get("Content-Length", "0"))
+            written = 0
+            chunk = 1024 * 256  # 256 KiB
+            next_log = 50 * 1024 * 1024  # log every 50 MB
+            with tmp.open("wb") as f:
+                while True:
+                    buf = resp.read(chunk)
+                    if not buf:
+                        break
+                    f.write(buf)
+                    written += len(buf)
+                    if written >= next_log:
+                        if total > 0:
+                            logger.info(
+                                "CLAP setup: %s — %d / %d MB (%.0f%%)",
+                                label,
+                                written // (1024 * 1024),
+                                total // (1024 * 1024),
+                                100.0 * written / total,
+                            )
+                        else:
+                            logger.info("CLAP setup: %s — %d MB", label, written // (1024 * 1024))
+                        next_log += 50 * 1024 * 1024
+
+        if not _file_ok(tmp, min_size):
+            raise RuntimeError(f"downloaded {label} is too small ({tmp.stat().st_size} bytes < {min_size})")
+        os.replace(tmp, dest)
+        logger.info("CLAP setup: installed %s -> %s (%d MB)", label, dest, dest.stat().st_size // (1024 * 1024))
+    except Exception:
+        # Best-effort cleanup of the partial file. Re-raise so the caller can log + skip.
+        try:
+            if tmp.exists():
+                tmp.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def _ensure_clap_models_sync() -> None:
+    """Synchronous core. Called from the async wrapper inside a thread."""
+    if not settings.CLAP_ENABLED:
+        return
+
+    base = Path(settings.CLAP_MODEL_DIR)
+    targets = [
+        ("text", base / settings.CLAP_TEXT_MODEL_FILE, settings.CLAP_TEXT_MODEL_URL, _MIN_SIZES["text"]),
+        ("audio", base / settings.CLAP_AUDIO_MODEL_FILE, settings.CLAP_AUDIO_MODEL_URL, _MIN_SIZES["audio"]),
+        (
+            "tokenizer",
+            base / settings.CLAP_TOKENIZER_FILE,
+            settings.CLAP_TOKENIZER_URL,
+            _MIN_SIZES["tokenizer"],
+        ),
+    ]
+
+    missing = [(label, dest, url, ms) for label, dest, url, ms in targets if not _file_ok(dest, ms)]
+    if not missing:
+        logger.info("CLAP setup: all 3 model files already present at %s", base)
+        return
+
+    logger.info(
+        "CLAP setup: %d/%d files missing or partial — downloading into %s",
+        len(missing),
+        len(targets),
+        base,
+    )
+    for label, dest, url, min_size in missing:
+        try:
+            _download_one(url, dest, min_size, label)
+        except (urllib.error.URLError, OSError, RuntimeError) as e:
+            logger.warning(
+                "CLAP setup: failed to download %s from %s: %s — text strategy will return 503 until this resolves",
+                label,
+                url,
+                e,
+            )
+
+
+async def ensure_clap_models() -> None:
+    """Async entry point. Runs the (potentially slow) blocking download in a thread."""
+    if not settings.CLAP_ENABLED:
+        return
+    await asyncio.to_thread(_ensure_clap_models_sync)

--- a/app/services/clap_text.py
+++ b/app/services/clap_text.py
@@ -97,7 +97,6 @@ def _load() -> None:
         raise RuntimeError("CLAP text ONNX model has no inputs")
 
     with _lock:
-        global _session, _tokenizer, _input_name
         _session = session
         _tokenizer = tokenizer
         _input_name = inputs[0].name

--- a/tests/test_clap_setup.py
+++ b/tests/test_clap_setup.py
@@ -1,0 +1,142 @@
+"""
+GrooveIQ — Tests for the CLAP auto-installer (issue #91).
+
+Verifies the no-op paths (CLAP disabled, files already present) and the
+download path with a mocked HTTP fetch — we don't pull 400 MB in CI.
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+from unittest.mock import patch
+
+import pytest
+
+from app.services import clap_setup
+
+
+class _FakeResponse:
+    """Minimal ``urlopen`` return value: streams a fixed payload then EOFs."""
+
+    def __init__(self, payload: bytes, content_length: int | None = None):
+        self._buf = BytesIO(payload)
+        self.headers = {"Content-Length": str(content_length if content_length is not None else len(payload))}
+
+    def read(self, n: int = -1) -> bytes:
+        return self._buf.read(n)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        self._buf.close()
+
+
+class TestEnsureClapModelsSync:
+    def test_noop_when_disabled(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(clap_setup.settings, "CLAP_ENABLED", False)
+        monkeypatch.setattr(clap_setup.settings, "CLAP_MODEL_DIR", str(tmp_path))
+
+        with patch.object(clap_setup, "_download_one") as m:
+            clap_setup._ensure_clap_models_sync()
+
+        assert m.call_count == 0
+        assert list(tmp_path.iterdir()) == []
+
+    def test_noop_when_files_already_present(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(clap_setup.settings, "CLAP_ENABLED", True)
+        monkeypatch.setattr(clap_setup.settings, "CLAP_MODEL_DIR", str(tmp_path))
+        monkeypatch.setattr(clap_setup.settings, "CLAP_TEXT_MODEL_FILE", "clap_text.onnx")
+        monkeypatch.setattr(clap_setup.settings, "CLAP_AUDIO_MODEL_FILE", "clap_audio.onnx")
+        monkeypatch.setattr(clap_setup.settings, "CLAP_TOKENIZER_FILE", "clap_tokenizer.json")
+
+        # Pre-create files at min sizes so _file_ok returns True for all three.
+        (tmp_path / "clap_text.onnx").write_bytes(b"x" * clap_setup._MIN_SIZES["text"])
+        (tmp_path / "clap_audio.onnx").write_bytes(b"x" * clap_setup._MIN_SIZES["audio"])
+        (tmp_path / "clap_tokenizer.json").write_bytes(b"x" * clap_setup._MIN_SIZES["tokenizer"])
+
+        with patch.object(clap_setup, "_download_one") as m:
+            clap_setup._ensure_clap_models_sync()
+
+        assert m.call_count == 0
+
+    def test_downloads_only_missing_files(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(clap_setup.settings, "CLAP_ENABLED", True)
+        monkeypatch.setattr(clap_setup.settings, "CLAP_MODEL_DIR", str(tmp_path))
+        monkeypatch.setattr(clap_setup.settings, "CLAP_TEXT_MODEL_FILE", "clap_text.onnx")
+        monkeypatch.setattr(clap_setup.settings, "CLAP_AUDIO_MODEL_FILE", "clap_audio.onnx")
+        monkeypatch.setattr(clap_setup.settings, "CLAP_TOKENIZER_FILE", "clap_tokenizer.json")
+
+        # Pre-create only the tokenizer at sufficient size.
+        (tmp_path / "clap_tokenizer.json").write_bytes(b"x" * clap_setup._MIN_SIZES["tokenizer"])
+
+        with patch.object(clap_setup, "_download_one") as m:
+            clap_setup._ensure_clap_models_sync()
+
+        called_labels = sorted(call.args[3] for call in m.call_args_list)
+        assert called_labels == ["audio", "text"]
+
+    def test_partial_file_redownloaded(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(clap_setup.settings, "CLAP_ENABLED", True)
+        monkeypatch.setattr(clap_setup.settings, "CLAP_MODEL_DIR", str(tmp_path))
+        monkeypatch.setattr(clap_setup.settings, "CLAP_TEXT_MODEL_FILE", "clap_text.onnx")
+        monkeypatch.setattr(clap_setup.settings, "CLAP_AUDIO_MODEL_FILE", "clap_audio.onnx")
+        monkeypatch.setattr(clap_setup.settings, "CLAP_TOKENIZER_FILE", "clap_tokenizer.json")
+
+        # Tiny "text" file — too small, must be re-fetched.
+        (tmp_path / "clap_text.onnx").write_bytes(b"x" * 10)
+        (tmp_path / "clap_audio.onnx").write_bytes(b"x" * clap_setup._MIN_SIZES["audio"])
+        (tmp_path / "clap_tokenizer.json").write_bytes(b"x" * clap_setup._MIN_SIZES["tokenizer"])
+
+        with patch.object(clap_setup, "_download_one") as m:
+            clap_setup._ensure_clap_models_sync()
+
+        called_labels = sorted(call.args[3] for call in m.call_args_list)
+        assert called_labels == ["text"]
+
+    def test_download_failure_is_swallowed(self, tmp_path, monkeypatch, caplog):
+        monkeypatch.setattr(clap_setup.settings, "CLAP_ENABLED", True)
+        monkeypatch.setattr(clap_setup.settings, "CLAP_MODEL_DIR", str(tmp_path))
+        monkeypatch.setattr(clap_setup.settings, "CLAP_TEXT_MODEL_FILE", "clap_text.onnx")
+        monkeypatch.setattr(clap_setup.settings, "CLAP_AUDIO_MODEL_FILE", "clap_audio.onnx")
+        monkeypatch.setattr(clap_setup.settings, "CLAP_TOKENIZER_FILE", "clap_tokenizer.json")
+
+        def _explode(*_, **__):
+            raise OSError("network down")
+
+        with patch.object(clap_setup, "_download_one", side_effect=_explode):
+            clap_setup._ensure_clap_models_sync()  # must NOT raise
+
+        # Files still missing — that's expected; the warning gets logged.
+        assert not (tmp_path / "clap_text.onnx").exists()
+
+
+class TestDownloadOne:
+    def test_atomic_rename_on_success(self, tmp_path):
+        dest = tmp_path / "clap_text.onnx"
+        payload = b"x" * (clap_setup._MIN_SIZES["text"] + 1024)
+
+        with patch.object(clap_setup.urllib.request, "urlopen", return_value=_FakeResponse(payload)):
+            clap_setup._download_one("https://example.invalid/text.onnx", dest, clap_setup._MIN_SIZES["text"], "text")
+
+        assert dest.is_file()
+        assert dest.stat().st_size == len(payload)
+        # No leftover temp files.
+        leftovers = [p for p in tmp_path.iterdir() if p.name.startswith(".clap_text")]
+        assert leftovers == []
+
+    def test_too_small_response_rejected(self, tmp_path):
+        dest = tmp_path / "clap_text.onnx"
+        # Payload smaller than min size — likely an HTML error page, not a model.
+        payload = b"<html>404</html>"
+
+        with (
+            patch.object(clap_setup.urllib.request, "urlopen", return_value=_FakeResponse(payload)),
+            pytest.raises(RuntimeError, match="too small"),
+        ):
+            clap_setup._download_one("https://example.invalid/text.onnx", dest, clap_setup._MIN_SIZES["text"], "text")
+
+        assert not dest.exists()
+        # And the temp file is cleaned up.
+        leftovers = [p for p in tmp_path.iterdir() if p.name.startswith(".clap_text")]
+        assert leftovers == []

--- a/tests/test_clap_setup.py
+++ b/tests/test_clap_setup.py
@@ -7,29 +7,31 @@ download path with a mocked HTTP fetch — we don't pull 400 MB in CI.
 
 from __future__ import annotations
 
-from io import BytesIO
-from unittest.mock import patch
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from app.services import clap_setup
 
 
-class _FakeResponse:
-    """Minimal ``urlopen`` return value: streams a fixed payload then EOFs."""
+@contextmanager
+def _mock_httpx_stream(payload: bytes):
+    """Patch ``httpx.Client`` so the streaming GET returns ``payload`` once."""
+    fake_resp = MagicMock()
+    fake_resp.headers = {"Content-Length": str(len(payload))}
+    fake_resp.raise_for_status = MagicMock()
+    fake_resp.iter_bytes = MagicMock(return_value=iter([payload]))
+    fake_resp.__enter__ = MagicMock(return_value=fake_resp)
+    fake_resp.__exit__ = MagicMock(return_value=False)
 
-    def __init__(self, payload: bytes, content_length: int | None = None):
-        self._buf = BytesIO(payload)
-        self.headers = {"Content-Length": str(content_length if content_length is not None else len(payload))}
+    fake_client = MagicMock()
+    fake_client.stream = MagicMock(return_value=fake_resp)
+    fake_client.__enter__ = MagicMock(return_value=fake_client)
+    fake_client.__exit__ = MagicMock(return_value=False)
 
-    def read(self, n: int = -1) -> bytes:
-        return self._buf.read(n)
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *_):
-        self._buf.close()
+    with patch.object(clap_setup.httpx, "Client", return_value=fake_client):
+        yield fake_client
 
 
 class TestEnsureClapModelsSync:
@@ -116,7 +118,7 @@ class TestDownloadOne:
         dest = tmp_path / "clap_text.onnx"
         payload = b"x" * (clap_setup._MIN_SIZES["text"] + 1024)
 
-        with patch.object(clap_setup.urllib.request, "urlopen", return_value=_FakeResponse(payload)):
+        with _mock_httpx_stream(payload):
             clap_setup._download_one("https://example.invalid/text.onnx", dest, clap_setup._MIN_SIZES["text"], "text")
 
         assert dest.is_file()
@@ -142,10 +144,7 @@ class TestDownloadOne:
         # Payload smaller than min size — likely an HTML error page, not a model.
         payload = b"<html>404</html>"
 
-        with (
-            patch.object(clap_setup.urllib.request, "urlopen", return_value=_FakeResponse(payload)),
-            pytest.raises(RuntimeError, match="too small"),
-        ):
+        with _mock_httpx_stream(payload), pytest.raises(RuntimeError, match="too small"):
             clap_setup._download_one("https://example.invalid/text.onnx", dest, clap_setup._MIN_SIZES["text"], "text")
 
         assert not dest.exists()

--- a/tests/test_clap_setup.py
+++ b/tests/test_clap_setup.py
@@ -125,6 +125,18 @@ class TestDownloadOne:
         leftovers = [p for p in tmp_path.iterdir() if p.name.startswith(".clap_text")]
         assert leftovers == []
 
+    def test_non_https_url_refused(self, tmp_path):
+        dest = tmp_path / "clap_text.onnx"
+        # file://, http://, ftp://, etc. must all be refused before we hit urlopen.
+        for bad in (
+            "file:///etc/passwd",
+            "http://example.invalid/text.onnx",
+            "ftp://example.invalid/text.onnx",
+        ):
+            with pytest.raises(ValueError, match="non-https"):
+                clap_setup._download_one(bad, dest, clap_setup._MIN_SIZES["text"], "text")
+        assert not dest.exists()
+
     def test_too_small_response_rejected(self, tmp_path):
         dest = tmp_path / "clap_text.onnx"
         # Payload smaller than min size — likely an HTML error page, not a model.


### PR DESCRIPTION
Closes #91.

## Summary
- **A.** Delete duplicate `global` in `clap_text.py:_load()` — fixes the Python 3.12 SyntaxError that breaks every text-strategy POST.
- **B.** Add `app/services/clap_setup.ensure_clap_models()` — async startup hook that downloads `text_model_fp16.onnx`, `audio_model_fp16.onnx`, and `tokenizer.json` from `Xenova/larger_clap_music_and_speech` on Hugging Face into `CLAP_MODEL_DIR` if missing. Total ~395 MB on first start, persisted in the existing `grooveiq_data` named volume. Failures log a warning and let startup proceed; the route surfaces a clean 503 instead.

## Behaviour summary
| Scenario | Result |
|---|---|
| `CLAP_ENABLED=false` | hook is no-op, all non-text strategies work as before |
| `CLAP_ENABLED=true`, fresh install | first start downloads ~395 MB into `/data/models/clap/` |
| `CLAP_ENABLED=true`, models present | no-op, startup is fast |
| Download fails (network down) | warning logged, startup proceeds, text endpoint → 503 |
| Partial / corrupt file | rejected by min-size check, re-downloaded next start |
| Operator wants a different variant / private mirror | override `CLAP_TEXT_MODEL_URL`, `CLAP_AUDIO_MODEL_URL`, `CLAP_TOKENIZER_URL` |

## Test plan
- [x] Unit tests cover: disabled no-op, files-present no-op, only-missing-downloaded, partial re-download, network failure swallowed, atomic rename, too-small-response rejected
- [ ] CI green
- [ ] After merge, deploy on local test server — watch startup logs for "CLAP setup: downloading text from …", verify files appear at `/data/models/clap/`
- [ ] POST a text-strategy playlist on prod and confirm 201 (assuming at least some tracks have a CLAP audio embedding; otherwise 503 is the correct response and the audio backfill needs a tick)

🤖 Generated with [Claude Code](https://claude.com/claude-code)