### PR TITLE
fix(deps): declare tokenizers>=0.15 — required by CLAP text encoder

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,10 @@ numpy>=2.4.4,<3
 # For Intel iGPU acceleration, install onnxruntime-openvino instead.
 onnxruntime>=1.25.1
 
+# HuggingFace tokenizers — required by the CLAP text encoder (clap_text.py).
+# CLAP playlists (POST /v1/playlists strategy=text) silently 503 without it.
+tokenizers>=0.15
+
 # Candidate generation (Phase 4)
 faiss-cpu>=1.13.2
 implicit>=0.7.2


### PR DESCRIPTION
Found while verifying the #91 fix on prod. The CLAP text encoder imports \`tokenizers\` but the package was never declared in \`requirements.txt\` — it was apparently present transitively in earlier images, then disappeared on a clean rebuild.

Result: every \`POST /v1/playlists\` with \`strategy=text\` returned **503** with detail:
\`\"CLAP text encoding failed: The 'tokenizers' package is required for CLAP text encoding. Install with: pip install tokenizers>=0.15\"\`

(The 503 itself is the new correct behaviour from the previous PR; the underlying problem is that the dep was missing in the first place.)

## Fix
One-line addition to requirements.txt: \`tokenizers>=0.15\` (the version pinned by the CLAP module's own error message).

## Test plan
- [ ] CI green
- [ ] After deploy, hit \`POST /v1/playlists\` strategy=text on local test server → expect either 503 with \"No tracks have CLAP embeddings yet\" (until backfill completes) or 201 with results (once the backfill produces some embeddings). Either is fine; the key check is that the message no longer says \"tokenizers package is required\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)