### PR TITLE
fix(clap): switch default ONNX weights from fp16 to fp32 (avoids ORT load crash)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -154,14 +154,17 @@ class Settings(BaseSettings):
     CLAP_AUDIO_SR: int = 48000  # LAION-CLAP expects 48 kHz mono
     CLAP_AUDIO_CLIP_SECONDS: float = 10.0  # length of central slice fed to the audio encoder
 
-    # Auto-download URLs (issue #91). fp16 weights — half the size of fp32
-    # with negligible quality loss for retrieval. Each file lands in
-    # CLAP_MODEL_DIR under the corresponding *_FILE name above.
+    # Auto-download URLs (issue #91). fp32 weights — larger than fp16 but
+    # avoid an ONNX Runtime crash on model load: the fp16 text export
+    # interacts badly with the SimplifiedLayerNormFusion graph optimisation
+    # ("InsertedPrecisionFreeCast" node mismatch). Operators wanting
+    # smaller weights can override these to *_fp16.onnx and lower the ORT
+    # optimisation level in clap_text.py.
     CLAP_TEXT_MODEL_URL: str = (
-        "https://huggingface.co/Xenova/larger_clap_music_and_speech/resolve/main/onnx/text_model_fp16.onnx"
+        "https://huggingface.co/Xenova/larger_clap_music_and_speech/resolve/main/onnx/text_model.onnx"
     )
     CLAP_AUDIO_MODEL_URL: str = (
-        "https://huggingface.co/Xenova/larger_clap_music_and_speech/resolve/main/onnx/audio_model_fp16.onnx"
+        "https://huggingface.co/Xenova/larger_clap_music_and_speech/resolve/main/onnx/audio_model.onnx"
     )
     CLAP_TOKENIZER_URL: str = "https://huggingface.co/Xenova/larger_clap_music_and_speech/resolve/main/tokenizer.json"
 

--- a/app/services/clap_setup.py
+++ b/app/services/clap_setup.py
@@ -33,11 +33,13 @@ from app.core.config import settings
 logger = logging.getLogger(__name__)
 
 # Minimum plausible byte size for each file. Catches partial downloads,
-# 404 HTML pages saved as .onnx, etc. Sizes are based on Xenova fp16
-# weights with ~30% slack to tolerate variant swaps.
+# 404 HTML pages saved as .onnx, etc. Sizes are calibrated to the fp32
+# Xenova weights and deliberately above the fp16 sizes — that way a stale
+# fp16 install (default before issue #91 follow-up) gets re-downloaded as
+# fp32 automatically on the next start.
 _MIN_SIZES = {
-    "text": 100 * 1024 * 1024,  # text_model_fp16.onnx is ~251 MB
-    "audio": 50 * 1024 * 1024,  # audio_model_fp16.onnx is ~143 MB
+    "text": 300 * 1024 * 1024,  # text_model.onnx is ~478 MB; fp16 is ~239 MB (rejected)
+    "audio": 200 * 1024 * 1024,  # audio_model.onnx is ~269 MB; fp16 is ~137 MB (rejected)
     "tokenizer": 1 * 1024 * 1024,  # tokenizer.json is ~2 MB
 }
 

--- a/tests/test_clap_setup.py
+++ b/tests/test_clap_setup.py
@@ -14,6 +14,11 @@ import pytest
 
 from app.services import clap_setup
 
+# Tiny stand-in sizes so tests don't allocate hundreds of MB of zeroes
+# just to satisfy the production min-size validation. Each test that
+# writes a placeholder file monkeypatches this in.
+_TEST_MIN_SIZES = {"text": 1024, "audio": 1024, "tokenizer": 256}
+
 
 @contextmanager
 def _mock_httpx_stream(payload: bytes):
@@ -46,6 +51,7 @@ class TestEnsureClapModelsSync:
         assert list(tmp_path.iterdir()) == []
 
     def test_noop_when_files_already_present(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(clap_setup, "_MIN_SIZES", _TEST_MIN_SIZES)
         monkeypatch.setattr(clap_setup.settings, "CLAP_ENABLED", True)
         monkeypatch.setattr(clap_setup.settings, "CLAP_MODEL_DIR", str(tmp_path))
         monkeypatch.setattr(clap_setup.settings, "CLAP_TEXT_MODEL_FILE", "clap_text.onnx")
@@ -53,9 +59,9 @@ class TestEnsureClapModelsSync:
         monkeypatch.setattr(clap_setup.settings, "CLAP_TOKENIZER_FILE", "clap_tokenizer.json")
 
         # Pre-create files at min sizes so _file_ok returns True for all three.
-        (tmp_path / "clap_text.onnx").write_bytes(b"x" * clap_setup._MIN_SIZES["text"])
-        (tmp_path / "clap_audio.onnx").write_bytes(b"x" * clap_setup._MIN_SIZES["audio"])
-        (tmp_path / "clap_tokenizer.json").write_bytes(b"x" * clap_setup._MIN_SIZES["tokenizer"])
+        (tmp_path / "clap_text.onnx").write_bytes(b"x" * _TEST_MIN_SIZES["text"])
+        (tmp_path / "clap_audio.onnx").write_bytes(b"x" * _TEST_MIN_SIZES["audio"])
+        (tmp_path / "clap_tokenizer.json").write_bytes(b"x" * _TEST_MIN_SIZES["tokenizer"])
 
         with patch.object(clap_setup, "_download_one") as m:
             clap_setup._ensure_clap_models_sync()
@@ -63,6 +69,7 @@ class TestEnsureClapModelsSync:
         assert m.call_count == 0
 
     def test_downloads_only_missing_files(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(clap_setup, "_MIN_SIZES", _TEST_MIN_SIZES)
         monkeypatch.setattr(clap_setup.settings, "CLAP_ENABLED", True)
         monkeypatch.setattr(clap_setup.settings, "CLAP_MODEL_DIR", str(tmp_path))
         monkeypatch.setattr(clap_setup.settings, "CLAP_TEXT_MODEL_FILE", "clap_text.onnx")
@@ -70,7 +77,7 @@ class TestEnsureClapModelsSync:
         monkeypatch.setattr(clap_setup.settings, "CLAP_TOKENIZER_FILE", "clap_tokenizer.json")
 
         # Pre-create only the tokenizer at sufficient size.
-        (tmp_path / "clap_tokenizer.json").write_bytes(b"x" * clap_setup._MIN_SIZES["tokenizer"])
+        (tmp_path / "clap_tokenizer.json").write_bytes(b"x" * _TEST_MIN_SIZES["tokenizer"])
 
         with patch.object(clap_setup, "_download_one") as m:
             clap_setup._ensure_clap_models_sync()
@@ -79,6 +86,7 @@ class TestEnsureClapModelsSync:
         assert called_labels == ["audio", "text"]
 
     def test_partial_file_redownloaded(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(clap_setup, "_MIN_SIZES", _TEST_MIN_SIZES)
         monkeypatch.setattr(clap_setup.settings, "CLAP_ENABLED", True)
         monkeypatch.setattr(clap_setup.settings, "CLAP_MODEL_DIR", str(tmp_path))
         monkeypatch.setattr(clap_setup.settings, "CLAP_TEXT_MODEL_FILE", "clap_text.onnx")
@@ -87,8 +95,8 @@ class TestEnsureClapModelsSync:
 
         # Tiny "text" file — too small, must be re-fetched.
         (tmp_path / "clap_text.onnx").write_bytes(b"x" * 10)
-        (tmp_path / "clap_audio.onnx").write_bytes(b"x" * clap_setup._MIN_SIZES["audio"])
-        (tmp_path / "clap_tokenizer.json").write_bytes(b"x" * clap_setup._MIN_SIZES["tokenizer"])
+        (tmp_path / "clap_audio.onnx").write_bytes(b"x" * _TEST_MIN_SIZES["audio"])
+        (tmp_path / "clap_tokenizer.json").write_bytes(b"x" * _TEST_MIN_SIZES["tokenizer"])
 
         with patch.object(clap_setup, "_download_one") as m:
             clap_setup._ensure_clap_models_sync()
@@ -116,10 +124,13 @@ class TestEnsureClapModelsSync:
 class TestDownloadOne:
     def test_atomic_rename_on_success(self, tmp_path):
         dest = tmp_path / "clap_text.onnx"
-        payload = b"x" * (clap_setup._MIN_SIZES["text"] + 1024)
+        # Use a small min_size local to this test; the production constant
+        # is 300 MB and we don't want to allocate that in CI.
+        min_size = 1024
+        payload = b"x" * (min_size + 256)
 
         with _mock_httpx_stream(payload):
-            clap_setup._download_one("https://example.invalid/text.onnx", dest, clap_setup._MIN_SIZES["text"], "text")
+            clap_setup._download_one("https://example.invalid/text.onnx", dest, min_size, "text")
 
         assert dest.is_file()
         assert dest.stat().st_size == len(payload)
@@ -143,9 +154,10 @@ class TestDownloadOne:
         dest = tmp_path / "clap_text.onnx"
         # Payload smaller than min size — likely an HTML error page, not a model.
         payload = b"<html>404</html>"
+        min_size = 1024
 
         with _mock_httpx_stream(payload), pytest.raises(RuntimeError, match="too small"):
-            clap_setup._download_one("https://example.invalid/text.onnx", dest, clap_setup._MIN_SIZES["text"], "text")
+            clap_setup._download_one("https://example.invalid/text.onnx", dest, min_size, "text")
 
         assert not dest.exists()
         # And the temp file is cleaned up.


### PR DESCRIPTION
Found while finishing the #91 verification on prod. The \`Xenova/larger_clap_music_and_speech\` fp16 text encoder export crashes ONNX Runtime on session init. Symptom on local test server today:

    POST /v1/playlists strategy=text  ->  503
    \"CLAP text encoding failed: [ONNXRuntimeError] : 1 : FAIL : Exception
     during initialization: ... SimplifiedLayerNormFusion\"

The fp16 graph is missing an \`InsertedPrecisionFreeCast_...\` node that the \`SimplifiedLayerNormFusion\` optimisation pass expects. The fp32 weights load cleanly.

## Tradeoff
| | Text | Audio | Total |
|---|---|---|---|
| fp16 (was) | 251 MB | 143 MB | ~395 MB |
| fp32 (now) | 502 MB | 282 MB | ~786 MB |

Doubles the one-time download but makes \`POST /v1/playlists strategy=text\` actually work. Easy operator override (\`CLAP_*_MODEL_URL\` env vars) for anyone who wants fp16 + a lowered ORT optimisation level.

## What also changes
- \`_MIN_SIZES\` is bumped above the fp16 file sizes so existing fp16 installs are treated as \"partial / re-download\" on the next start. Operators don't have to manually delete the fp16 files.
- Tests now monkeypatch \`_MIN_SIZES\` to small values so they don't allocate ~700 MB of zero-byte placeholders in CI.

## Test plan
- [ ] CI green
- [ ] After deploy to local test server, restart should auto-redownload fp32 over the existing fp16 files (logs will show \"3/3 files missing or partial\"). Then \`POST /v1/playlists strategy=text\` should reach the actual \"no embeddings yet\" 503 instead of the ONNX init crash 503.

🤖 Generated with [Claude Code](https://claude.com/claude-code)