### PR TITLE
fix(clap): mel-spectrogram preprocessing + GPU-aware audio session

### DIFF
--- a/app/services/analysis_worker.py
+++ b/app/services/analysis_worker.py
@@ -587,15 +587,49 @@ def _detect_onnx_backend() -> str:
     return "cpu"
 
 
+def _build_onnx_providers(cache_dir: str) -> list:
+    """Build the ONNX Runtime provider chain (OpenVINO → CUDA → CPU).
+
+    ``cache_dir`` is used as the OpenVINO compile-cache location; pass a
+    per-model directory if you want isolated caches.
+    """
+    backend = _detect_onnx_backend()
+    providers: list = []
+    if backend == "openvino":
+        providers.append(
+            (
+                "OpenVINOExecutionProvider",
+                {
+                    "device_type": "GPU",
+                    "precision": "FP16",
+                    "cache_dir": cache_dir,
+                },
+            )
+        )
+    elif backend == "cuda":
+        providers.append(
+            (
+                "CUDAExecutionProvider",
+                {
+                    "device_id": 0,
+                    "arena_extend_strategy": "kSameAsRequested",
+                    "gpu_mem_limit": 512 * 1024 * 1024,
+                },
+            )
+        )
+    providers.append("CPUExecutionProvider")
+    return providers
+
+
 def _init_clap_audio_session() -> object | None:
     """
     Load the CLAP audio tower ONNX session, if CLAP is enabled and the model
     file exists. Returns an ``onnxruntime.InferenceSession`` or ``None``.
 
-    Unlike the EffNet models, CLAP models are **not auto-downloaded** — they
-    have to be exported by the operator (LAION-CLAP's export_onnx.py) and
-    dropped into ``CLAP_MODEL_DIR``. We fail soft here so workers still boot
-    for non-CLAP deployments.
+    Auto-downloaded by ``app/services/clap_setup.py`` on first start (issue
+    #91). Operators can pre-place the file in ``CLAP_MODEL_DIR`` for
+    air-gapped installs. We fail soft here so workers still boot when CLAP
+    is disabled or download failed.
     """
     from app.core.config import settings
 
@@ -621,13 +655,19 @@ def _init_clap_audio_session() -> object | None:
     opts.intra_op_num_threads = settings.ANALYSIS_ONNX_INTRA_THREADS
     opts.inter_op_num_threads = settings.ANALYSIS_ONNX_INTER_THREADS
 
+    providers = _build_onnx_providers(os.path.join(settings.CLAP_MODEL_DIR, "_ov_cache"))
+
     try:
         session = ort.InferenceSession(
             model_path,
             sess_options=opts,
-            providers=["CPUExecutionProvider"],
+            providers=providers,
         )
-        logger.info("CLAP audio encoder loaded: %s", os.path.basename(model_path))
+        logger.info(
+            "CLAP audio encoder loaded: %s, providers=%s",
+            os.path.basename(model_path),
+            session.get_providers(),
+        )
         return session
     except Exception as e:
         logger.warning("Failed to load CLAP audio model: %s", e)
@@ -646,7 +686,6 @@ def _init_onnx_sessions() -> dict:
         logger.warning("Some ONNX models missing — ML features may be incomplete")
 
     models_dir = _get_models_dir()
-    backend = _detect_onnx_backend()
 
     sess_opts = ort.SessionOptions()
     sess_opts.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
@@ -655,30 +694,8 @@ def _init_onnx_sessions() -> dict:
     sess_opts.intra_op_num_threads = settings.ANALYSIS_ONNX_INTRA_THREADS
     sess_opts.inter_op_num_threads = settings.ANALYSIS_ONNX_INTER_THREADS
 
-    providers: list = []
-    if backend == "openvino":
-        providers.append(
-            (
-                "OpenVINOExecutionProvider",
-                {
-                    "device_type": "GPU",
-                    "precision": "FP16",
-                    "cache_dir": os.path.join(models_dir, "_ov_cache"),
-                },
-            )
-        )
-    elif backend == "cuda":
-        providers.append(
-            (
-                "CUDAExecutionProvider",
-                {
-                    "device_id": 0,
-                    "arena_extend_strategy": "kSameAsRequested",
-                    "gpu_mem_limit": 512 * 1024 * 1024,
-                },
-            )
-        )
-    providers.append("CPUExecutionProvider")
+    providers = _build_onnx_providers(os.path.join(models_dir, "_ov_cache"))
+    backend = _detect_onnx_backend()
 
     sessions: dict = {}
     for filename in _ONNX_MODELS:
@@ -1262,6 +1279,60 @@ def _build_embedding(
 # ---------------------------------------------------------------------------
 
 
+# Per-process cache of the HF feature extractor. Lazily built on first use
+# inside the worker, then reused for the lifetime of the worker.
+_clap_feature_extractor = None
+
+
+def _get_clap_feature_extractor():
+    """Return a cached ``ClapFeatureExtractor`` configured for Xenova's
+    ``larger_clap_music_and_speech`` export.
+
+    Parameters are pinned to match the upstream ``preprocessor_config.json``
+    (truncation=rand_trunc, frequency_min=50, …) so we don't need network
+    access to ``from_pretrained`` at runtime.
+
+    The Xenova export expects a 4-D ``(batch, 1, 1001, 64)`` mel input —
+    not the 4-channel fusion stack used by ``clap-htsat-fused``. The
+    ``rand_trunc`` truncation produces this shape directly.
+
+    HuggingFace's ``feature_extraction_clap`` does ``import torch`` at
+    module level (only used by ``_random_mel_fusion`` in fusion mode,
+    which we never trigger). To keep ``transformers`` from pulling in a
+    ~700 MB torch dep, we install a no-op stub for the ``torch`` module
+    before the first import.
+    """
+    global _clap_feature_extractor
+    if _clap_feature_extractor is not None:
+        return _clap_feature_extractor
+
+    import importlib.machinery
+    import sys
+    import types
+
+    if "torch" not in sys.modules:
+        torch_stub = types.ModuleType("torch")
+        torch_stub.__spec__ = importlib.machinery.ModuleSpec("torch", loader=None)
+        torch_stub.__version__ = "0.0.0+grooveiq-stub"
+        sys.modules["torch"] = torch_stub
+
+    from transformers.models.clap.feature_extraction_clap import ClapFeatureExtractor
+
+    _clap_feature_extractor = ClapFeatureExtractor(
+        feature_size=64,
+        sampling_rate=48000,
+        hop_length=480,
+        max_length_s=10,
+        fft_window_size=1024,
+        padding_value=0.0,
+        frequency_min=50,
+        frequency_max=14000,
+        padding="repeatpad",
+        truncation="rand_trunc",
+    )
+    return _clap_feature_extractor
+
+
 def _compute_clap_embedding(
     audio: np.ndarray,
     sr: int,
@@ -1269,23 +1340,22 @@ def _compute_clap_embedding(
     es,
 ) -> np.ndarray | None:
     """
-    Encode the central clip of ``audio`` (loaded at 16 kHz for EffNet) into a
-    512-dim CLAP embedding. Returns an L2-normalised float32 vector, or None
-    on failure.
+    Encode ``audio`` into a 512-dim CLAP embedding. Returns an L2-normalised
+    float32 vector, or ``None`` on failure.
 
     Steps:
-      1. Slice the central ``CLAP_AUDIO_CLIP_SECONDS`` of audio.
-      2. Resample from 16 kHz → ``CLAP_AUDIO_SR`` (default 48 kHz) via
-         Essentia's Resample (no new dep).
-      3. Run through the CLAP audio encoder ONNX session.
-      4. L2-normalise.
-
-    The exact input layout (raw waveform vs mel-spectrogram) depends on how
-    the CLAP ONNX was exported. LAION-CLAP's ``export_onnx.py`` produces a
-    model that takes raw ``float32`` audio at 48 kHz, padded to exactly
-    ``CLAP_AUDIO_CLIP_SECONDS`` seconds. If your export differs, adapt the
-    pre-processing here — the model input/output shapes are logged on first
-    call for easy debugging.
+      1. Slice the central ``CLAP_AUDIO_CLIP_SECONDS`` of audio (bounded
+         CPU/memory; also makes the embedding deterministic — without
+         this, ``ClapFeatureExtractor`` random-crops longer audio).
+      2. Resample from the source sample rate (16 kHz upstream from the
+         EffNet pipeline) → ``CLAP_AUDIO_SR`` (default 48 kHz) via
+         Essentia's Resample.
+      3. Build the 4-D mel-spectrogram input ``(1, 1, 1001, 64)`` via
+         HF's ``ClapFeatureExtractor`` — Xenova's ONNX export expects
+         pre-computed log-mel features, not raw waveforms.
+      4. Run through the CLAP audio encoder ONNX session.
+      5. L2-normalise so the vector is comparable via dot-product to the
+         text embeddings stored in ``TrackFeatures.clap_embedding``.
     """
     from app.core.config import settings
 
@@ -1293,7 +1363,7 @@ def _compute_clap_embedding(
     target_sr = int(settings.CLAP_AUDIO_SR)
     target_len = int(clip_seconds * target_sr)
 
-    # 1. Central slice at the current sample rate.
+    # 1. Central slice at the source sample rate (bounds resample cost).
     src_clip_samples = int(clip_seconds * sr)
     if len(audio) > src_clip_samples:
         start = (len(audio) - src_clip_samples) // 2
@@ -1301,7 +1371,7 @@ def _compute_clap_embedding(
     else:
         clip = audio
 
-    # 2. Resample 16k → 48k (if needed).
+    # 2. Resample to the model's expected rate.
     if sr != target_sr:
         try:
             resample = es.Resample(inputSampleRate=sr, outputSampleRate=target_sr, quality=1)
@@ -1309,33 +1379,46 @@ def _compute_clap_embedding(
         except Exception as e:
             logger.debug("Resample to %d Hz failed, using raw: %s", target_sr, e)
 
-    # 3. Pad / truncate to exactly target_len samples (model expects fixed shape).
-    if len(clip) < target_len:
-        padded = np.zeros(target_len, dtype=np.float32)
-        padded[: len(clip)] = clip
-        clip = padded
-    else:
+    clip = np.asarray(clip, dtype=np.float32)
+
+    # Hard-cap to target_len samples so the extractor takes the deterministic
+    # pad path (audio == max_length, no random crop). Resample rounding can
+    # produce ±1 sample of slack so we always truncate.
+    if len(clip) > target_len:
         clip = clip[:target_len]
 
-    # 4. Run model. Handle both (1, N) and (N,) input layouts.
+    # 3. Mel-spectrogram features. The extractor pads (via repeat-pad) to
+    #    max_length_s, computes a log-mel spectrogram, and returns shape
+    #    ``(batch=1, channels=1, height=1001, width=64)``.
+    try:
+        fe = _get_clap_feature_extractor()
+        features = fe(
+            clip,
+            sampling_rate=target_sr,
+            return_tensors="np",
+        )
+    except Exception as e:
+        logger.debug("CLAP feature extraction failed: %s", e)
+        return None
+
+    input_features = np.asarray(features["input_features"], dtype=np.float32)
+
+    # 4. Run model.
     inputs = clap_session.get_inputs()
     if not inputs:
         return None
-    input_meta = inputs[0]
-    input_name = input_meta.name
-
-    batched = clip.astype(np.float32).reshape(1, -1)
+    input_name = inputs[0].name
 
     try:
-        outputs = clap_session.run(None, {input_name: batched})
+        outputs = clap_session.run(None, {input_name: input_features})
     except Exception as e:
         # Log shape on first failure so operators can diagnose export mismatches.
         if not hasattr(_compute_clap_embedding, "_logged_shape"):
             _compute_clap_embedding._logged_shape = True
             logger.warning(
                 "CLAP inference failed: input_shape=%s, model_expects=%s, err=%s",
-                batched.shape,
-                input_meta.shape,
+                input_features.shape,
+                inputs[0].shape,
                 e,
             )
         return None

--- a/app/services/analysis_worker.py
+++ b/app/services/analysis_worker.py
@@ -1298,19 +1298,21 @@ def _get_clap_feature_extractor():
 
     HuggingFace's ``feature_extraction_clap`` does ``import torch`` at
     module level (only used by ``_random_mel_fusion`` in fusion mode,
-    which we never trigger). To keep ``transformers`` from pulling in a
-    ~700 MB torch dep, we install a no-op stub for the ``torch`` module
-    before the first import.
+    which we never trigger). If torch is already importable — e.g. on the
+    test runner where ``implicit`` and other ML deps pull it in — we use
+    the real module. In the production image (no torch in requirements)
+    we install a tiny no-op stub so the import succeeds; saves ~700 MB.
     """
     global _clap_feature_extractor
     if _clap_feature_extractor is not None:
         return _clap_feature_extractor
 
     import importlib.machinery
+    import importlib.util
     import sys
     import types
 
-    if "torch" not in sys.modules:
+    if "torch" not in sys.modules and importlib.util.find_spec("torch") is None:
         torch_stub = types.ModuleType("torch")
         torch_stub.__spec__ = importlib.machinery.ModuleSpec("torch", loader=None)
         torch_stub.__version__ = "0.0.0+grooveiq-stub"

--- a/app/services/analysis_worker.py
+++ b/app/services/analysis_worker.py
@@ -1316,6 +1316,11 @@ def _get_clap_feature_extractor():
         torch_stub = types.ModuleType("torch")
         torch_stub.__spec__ = importlib.machinery.ModuleSpec("torch", loader=None)
         torch_stub.__version__ = "0.0.0+grooveiq-stub"
+        # scipy.array_api_compat / sklearn / lightgbm probe ``torch.Tensor``
+        # via ``issubclass`` to detect torch arrays. Provide a sentinel class
+        # so the probe returns False (correct: torch isn't really there)
+        # instead of crashing with AttributeError.
+        torch_stub.Tensor = type("Tensor", (), {})
         sys.modules["torch"] = torch_stub
 
     from transformers.models.clap.feature_extraction_clap import ClapFeatureExtractor

--- a/app/services/api_call_log.py
+++ b/app/services/api_call_log.py
@@ -34,8 +34,8 @@ logger = logging.getLogger(__name__)
 _log_queue: asyncio.Queue[ApiCallLog] | None = None
 _writer_task: asyncio.Task | None = None
 _FLUSH_INTERVAL_SECONDS = 1.0
-_MAX_QUEUE_SIZE = 5000   # If the flusher falls this far behind, drop new rows.
-_MAX_BATCH_SIZE = 500    # Bound the per-flush transaction.
+_MAX_QUEUE_SIZE = 5000  # If the flusher falls this far behind, drop new rows.
+_MAX_BATCH_SIZE = 500  # Bound the per-flush transaction.
 
 
 # Substrings (case-insensitive) of JSON keys whose values must never be persisted.
@@ -294,9 +294,7 @@ async def _flush_batch() -> None:
             session.add_all(rows)
             await session.commit()
     except Exception as e:
-        logger.warning(
-            "api_call_log batch flush failed (%d rows dropped): %s", len(rows), e
-        )
+        logger.warning("api_call_log batch flush failed (%d rows dropped): %s", len(rows), e)
 
 
 async def write_log(

--- a/app/static/js/v2/actions.js
+++ b/app/static/js/v2/actions.js
@@ -144,12 +144,12 @@
                     backfillClap.refresh({ lastRun: 'CLAP disabled — set CLAP_ENABLED=true to enable' });
                     return;
                 }
-                const pending = (stats.total || 0) - (stats.with_clap || 0);
+                const pending = (stats.total_tracks || 0) - (stats.with_clap_embedding || 0);
                 const cov = stats.coverage != null ? Math.round(stats.coverage * 100) : null;
                 backfillClap.refresh({
                     lastRun: pending > 0
                         ? pending.toLocaleString() + ' tracks pending · coverage ' + (cov != null ? cov + '%' : '—')
-                        : 'all tracks covered (' + (stats.with_clap || 0).toLocaleString() + ')',
+                        : 'all tracks covered (' + (stats.with_clap_embedding || 0).toLocaleString() + ')',
                 });
             }).catch(() => { /* leave blank */ });
         } else {

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,6 +47,17 @@ onnxruntime>=1.25.1
 # CLAP playlists (POST /v1/playlists strategy=text) silently 503 without it.
 tokenizers>=0.15
 
+# HuggingFace transformers — used in numpy mode for the CLAP audio feature
+# extractor (mel-spectrogram + fusion truncation). The Xenova ONNX export
+# expects pre-computed mel features, not raw waveforms.
+#
+# `feature_extraction_clap.py` does ``import torch`` at module level, but
+# only *uses* torch in ``_random_mel_fusion`` (audio > max_length_s branch).
+# We pre-clip to exactly max_length_s in analysis_worker._compute_clap_embedding,
+# so the numpy-only path is taken. A ~5-line stub of the ``torch`` module is
+# installed before the import — saves ~700 MB vs. installing real torch.
+transformers>=4.40,<5
+
 # Candidate generation (Phase 4)
 faiss-cpu>=1.13.2
 implicit>=0.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,12 +51,17 @@ tokenizers>=0.15
 # extractor (mel-spectrogram + fusion truncation). The Xenova ONNX export
 # expects pre-computed mel features, not raw waveforms.
 #
+# Pinned to >=5.0 to dodge CVE-2026-1839 (`Trainer._load_rng_state` calls
+# `torch.load` without `weights_only=True`). We don't use ``Trainer`` so
+# the vuln doesn't affect our usage, but pip-audit gates CI on it.
+#
 # `feature_extraction_clap.py` does ``import torch`` at module level, but
 # only *uses* torch in ``_random_mel_fusion`` (audio > max_length_s branch).
 # We pre-clip to exactly max_length_s in analysis_worker._compute_clap_embedding,
 # so the numpy-only path is taken. A ~5-line stub of the ``torch`` module is
-# installed before the import — saves ~700 MB vs. installing real torch.
-transformers>=4.40,<5
+# installed before the import (when torch isn't already available) —
+# saves ~700 MB vs. installing real torch.
+transformers>=5.0,<6
 
 # Candidate generation (Phase 4)
 faiss-cpu>=1.13.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,9 @@ _TEST_ENV = {
     # dedicated test_user_id.py module monkeypatches USER_ID_PATTERN to
     # the production default to verify enforcement under real config.
     "USER_ID_PATTERN": r"^[A-Za-z0-9_]+$",
+    # No API keys / auth in unit tests so importing settings doesn't
+    # hit the SystemExit guard in app/core/config.py.
+    "DISABLE_AUTH": "true",
 }
 
 for _k, _v in _TEST_ENV.items():

--- a/tests/test_clap_audio.py
+++ b/tests/test_clap_audio.py
@@ -1,0 +1,160 @@
+"""
+GrooveIQ — Tests for the CLAP audio embedding pipeline.
+
+Covers preprocessing (resample → ClapFeatureExtractor → 4-D mel input)
+and the ONNX inference call. We mock the ONNX session so the test stays
+fast and doesn't require the 269 MB Xenova audio model to be on disk.
+
+The transformers ``import torch`` workaround is exercised here too: if
+the test passes without ``torch`` installed in the venv, the stub is
+working correctly.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+# transformers is a hard dep of CLAP audio embeddings. Skip the whole
+# module if it's missing — clap_setup.py / requirements.txt make it a
+# soft dep at the operator level.
+pytest.importorskip("transformers")
+
+from app.services import analysis_worker
+
+
+@pytest.fixture(autouse=True)
+def _reset_extractor_cache():
+    """Each test starts with a fresh extractor so caching state doesn't
+    leak between tests."""
+    analysis_worker._clap_feature_extractor = None
+    yield
+    analysis_worker._clap_feature_extractor = None
+
+
+class TestGetClapFeatureExtractor:
+    def test_produces_expected_4d_shape_for_10s_audio(self):
+        """The Xenova larger_clap_music_and_speech ONNX expects (B, 1, 1001, 64).
+        rand_trunc + repeat-pad on a 10-second 48 kHz clip should yield exactly
+        that shape with batch=1."""
+        fe = analysis_worker._get_clap_feature_extractor()
+        audio = np.zeros(480_000, dtype=np.float32)
+        out = fe(audio, sampling_rate=48_000, return_tensors="np")
+        assert out["input_features"].shape == (1, 1, 1001, 64)
+        assert out["input_features"].dtype == np.float32
+
+    def test_handles_short_audio_via_repeat_pad(self):
+        """Audio shorter than max_length_s is repeat-padded; the output shape
+        must still be the model's required (1, 1, 1001, 64)."""
+        fe = analysis_worker._get_clap_feature_extractor()
+        audio = np.random.uniform(-0.1, 0.1, 48_000).astype(np.float32)  # 1s
+        out = fe(audio, sampling_rate=48_000, return_tensors="np")
+        assert out["input_features"].shape == (1, 1, 1001, 64)
+
+    def test_caches_extractor_instance(self):
+        a = analysis_worker._get_clap_feature_extractor()
+        b = analysis_worker._get_clap_feature_extractor()
+        assert a is b
+
+
+class TestComputeClapEmbedding:
+    @staticmethod
+    def _fake_session(output_vec=None):
+        """Mock ONNX session that returns a fixed 512-dim vector."""
+        if output_vec is None:
+            output_vec = np.arange(512, dtype=np.float32)
+        sess = MagicMock()
+        # Match the real model's input metadata so the code can read the name.
+        input_meta = MagicMock()
+        input_meta.name = "input_features"
+        input_meta.shape = ["audio_batch_size", "num_channels", "height", "width"]
+        sess.get_inputs.return_value = [input_meta]
+        sess.run.return_value = [output_vec.reshape(1, -1)]
+        return sess
+
+    def test_feeds_4d_mel_features_to_session(self):
+        """The session's ``run`` should be called with a 4-D float32 array
+        named ``input_features`` matching the model's expected shape."""
+        sess = self._fake_session()
+        audio = np.zeros(48_000 * 10, dtype=np.float32)  # 10s @ 48kHz
+
+        result = analysis_worker._compute_clap_embedding(audio, 48_000, sess, es=None)
+
+        assert result is not None
+        assert sess.run.called
+        feed = sess.run.call_args[0][1]
+        assert "input_features" in feed
+        feats = feed["input_features"]
+        assert feats.dtype == np.float32
+        assert feats.shape == (1, 1, 1001, 64)
+
+    def test_returns_l2_normalised_512_dim_vector(self):
+        sess = self._fake_session(output_vec=np.array([3.0, 4.0] + [0.0] * 510, dtype=np.float32))
+        audio = np.zeros(48_000 * 10, dtype=np.float32)
+
+        result = analysis_worker._compute_clap_embedding(audio, 48_000, sess, es=None)
+
+        assert result is not None
+        assert result.shape == (512,)
+        assert result.dtype == np.float32
+        assert abs(float(np.linalg.norm(result)) - 1.0) < 1e-5
+        # Direction preserved (3,4,0,...) → (0.6, 0.8, 0, ...)
+        assert abs(result[0] - 0.6) < 1e-5
+        assert abs(result[1] - 0.8) < 1e-5
+
+    def test_returns_none_when_model_emits_zero_vector(self):
+        """A degenerate zero embedding must surface as None, matching the
+        EffNet path behaviour (see #42 — storing zeros breaks FAISS)."""
+        sess = self._fake_session(output_vec=np.zeros(512, dtype=np.float32))
+        audio = np.zeros(48_000 * 10, dtype=np.float32)
+
+        result = analysis_worker._compute_clap_embedding(audio, 48_000, sess, es=None)
+
+        assert result is None
+
+    def test_returns_none_on_inference_failure(self):
+        sess = self._fake_session()
+        sess.run.side_effect = RuntimeError("simulated ORT crash")
+        audio = np.zeros(48_000 * 10, dtype=np.float32)
+
+        result = analysis_worker._compute_clap_embedding(audio, 48_000, sess, es=None)
+
+        assert result is None
+
+    def test_truncates_overlength_clip_to_target_len(self):
+        """If resample rounding produces > target_len samples, the function
+        truncates so the extractor stays on the deterministic pad path."""
+        sess = self._fake_session()
+        # Source rate = target rate, but audio length > 10s → pre-clip kicks in.
+        audio = np.random.uniform(-0.1, 0.1, 48_000 * 30).astype(np.float32)
+
+        result = analysis_worker._compute_clap_embedding(audio, 48_000, sess, es=None)
+
+        assert result is not None
+        feats = sess.run.call_args[0][1]["input_features"]
+        assert feats.shape == (1, 1, 1001, 64)
+
+
+class TestBuildOnnxProviders:
+    def test_cpu_only_when_no_gpu_available(self, monkeypatch):
+        """With no OpenVINO/CUDA EP available, only CPU should appear."""
+        monkeypatch.setattr(analysis_worker, "_detect_onnx_backend", lambda: "cpu")
+        providers = analysis_worker._build_onnx_providers("/tmp/cache")
+        assert providers == ["CPUExecutionProvider"]
+
+    def test_openvino_chain_when_intel_igpu_detected(self, monkeypatch):
+        monkeypatch.setattr(analysis_worker, "_detect_onnx_backend", lambda: "openvino")
+        providers = analysis_worker._build_onnx_providers("/tmp/cache")
+        assert len(providers) == 2
+        assert providers[0][0] == "OpenVINOExecutionProvider"
+        assert providers[0][1]["cache_dir"] == "/tmp/cache"
+        assert providers[1] == "CPUExecutionProvider"
+
+    def test_cuda_chain_when_cuda_available(self, monkeypatch):
+        monkeypatch.setattr(analysis_worker, "_detect_onnx_backend", lambda: "cuda")
+        providers = analysis_worker._build_onnx_providers("/tmp/cache")
+        assert len(providers) == 2
+        assert providers[0][0] == "CUDAExecutionProvider"
+        assert providers[1] == "CPUExecutionProvider"


### PR DESCRIPTION
## Summary

- **Fixes the CLAP audio backfill** — Xenova's audio ONNX expects pre-computed log-mel features of shape `(B, 1, 1001, 64)`, not raw waveforms. Every track was failing inference with `Conv: Input channels C is not equal to kernel channels * group`, producing `with_clap_embedding=0` for all 92 k tracks.
- **Wires up GPU offload for CLAP audio** — extracts `_build_onnx_providers()` and reuses it for the CLAP session (was hardcoded `CPUExecutionProvider`). With the host's `ANALYSIS_GPU` config the 92 k-track backfill should go from many hours to ~10–20 min.
- **No torch dep** — ClapFeatureExtractor's unconditional `import torch` is satisfied by a 5-line `sys.modules` stub. The torch-using `_random_mel_fusion` branch is only reached for audio > `max_length_s`, and we pre-clip to exactly `max_length_s`. Saves ~700 MB on the image.

## Implementation notes

- Pinned the extractor to Xenova's upstream `preprocessor_config.json` (`truncation=rand_trunc`, `frequency_min=50`, `padding=repeatpad`) so we don't need network access to `from_pretrained` at runtime.
- Pre-clip is now also a determinism guard — `rand_trunc` random-crops longer audio, which would make the same track produce different embeddings each run.
- New unit tests in `tests/test_clap_audio.py` cover the 4-D shape, repeat-pad of short clips, L2 normalisation, zero-vector → None, ORT crash → None, and the GPU provider chain.

## Drive-bys

- `_init_clap_audio_session` docstring said models aren't auto-downloaded — false since #92.
- `app/static/js/v2/actions.js` Backfill CLAP card was reading `stats.total` / `stats.with_clap` (always 0); now matches the API's `total_tracks` / `with_clap_embedding` (same names v1 dashboard uses).
- `tests/conftest.py` sets `DISABLE_AUTH=true` so local pytest doesn't trip the api-keys SystemExit when run without CI's env block.

## Test plan

- [x] `pytest tests/test_clap_audio.py` (11 passed)
- [x] End-to-end on the real prod ONNX file — ClapFeatureExtractor → ORT inference → 512-dim embedding with non-zero norm
- [x] `ruff check` + `ruff format --check` clean
- [ ] CI green
- [ ] After deploy on prod: `with_clap_embedding` starts climbing on `/v1/tracks/clap/stats`; `POST /v1/playlists strategy=text` returns 201 once embeddings exist
- [ ] Worker startup log shows `clap_audio=True` and the new providers line

🤖 Generated with [Claude Code](https://claude.com/claude-code)