### PR TITLE
fix(analysis): correct voice_instrumental column index (#99)

### DIFF
--- a/app/services/analysis_worker.py
+++ b/app/services/analysis_worker.py
@@ -1141,7 +1141,7 @@ def _extract_ml(
     else:
         heads = {
             "danceability": ("danceability-discogs-effnet-1.onnx", 0),
-            "instrumentalness": ("voice_instrumental-discogs-effnet-1.onnx", 1),
+            "instrumentalness": ("voice_instrumental-discogs-effnet-1.onnx", 0),
             # Valence used to be mapped to approachability_regression here,
             # but that model (a) measures a different concept (approach-
             # ability ≠ Russell-circumplex valence) and (b) has an unbounded

--- a/app/services/audio_analysis.py
+++ b/app/services/audio_analysis.py
@@ -38,7 +38,12 @@ import os
 # libraries (#88). The `mood_happy` channel turned out to be pinned to
 # [0, 0.46] across 67k tracks — useful for relative ranking, useless as
 # an absolute UI value or as a ranker feature with variance.
-ANALYSIS_VERSION = "2.6"
+# 2.7: corrected voice_instrumental column index — the head's classes are
+# ['instrumental', 'voice'] (col 0 = instrumental), but the code was reading
+# col 1, so 'instrumentalness' actually stored voice probability and the
+# derived 'speechiness = 1 - instrumentalness' was the instrumental
+# probability (#99). Same shape as the v2.5 mood inversion.
+ANALYSIS_VERSION = "2.7"
 
 # Must match FAISS index dimension (faiss_index._EMBEDDING_DIM).
 EMBEDDING_DIM = 64

--- a/app/services/gpu_inference.py
+++ b/app/services/gpu_inference.py
@@ -409,7 +409,7 @@ def infer_from_patches(
 
     heads = {
         "danceability": ("danceability-discogs-effnet-1.onnx", "softmax", 0),
-        "instrumentalness": ("voice_instrumental-discogs-effnet-1.onnx", "softmax", 1),
+        "instrumentalness": ("voice_instrumental-discogs-effnet-1.onnx", "softmax", 0),
         "valence": ("approachability_regression-discogs-effnet-1.onnx", "identity", 0),
         "mood_happy": ("mood_happy-discogs-effnet-1.onnx", "softmax", 0),
         "mood_sad": ("mood_sad-discogs-effnet-1.onnx", "softmax", 0),

--- a/tests/test_onnx_contracts.py
+++ b/tests/test_onnx_contracts.py
@@ -12,10 +12,10 @@ What this catches that Layer 1 misses:
     inversion (fixed in c67f235): all three were reading col 0 when the
     named class lived at col 1. Pre-fix this would have failed the
     semantic-class assertion immediately.
-  - #99 ``voice_instrumental`` column inversion (open): code reads col 1
-    (= ``voice``) and stores it under the field named
-    ``instrumentalness``. The semantic-class assertion below FAILS RED
-    until #99 lands.
+  - #99 ``voice_instrumental`` column inversion (fixed in v2.7): code
+    used to read col 1 (= ``voice``) and store it under the field named
+    ``instrumentalness``. The semantic-class assertion below pins col 0
+    so a re-introduction would fail RED.
   - A future model file replacement that silently shifts the class
     ordering (e.g. someone re-exports the ONNX with a different output
     layout). The shape + class-list assertions catch that at CI time
@@ -69,7 +69,7 @@ FIELD_SEMANTIC_CLASS: dict[str, str] = {
 # ``test_mirror_matches_analyzer_source`` test below catches drift.
 ANALYZER_FIELD_TO_HEAD: dict[str, tuple[str, int]] = {
     "danceability": ("danceability-discogs-effnet-1.onnx", 0),
-    "instrumentalness": ("voice_instrumental-discogs-effnet-1.onnx", 1),
+    "instrumentalness": ("voice_instrumental-discogs-effnet-1.onnx", 0),
     "happy": ("mood_happy-discogs-effnet-1.onnx", 0),
     "sad": ("mood_sad-discogs-effnet-1.onnx", 1),
     "aggressive": ("mood_aggressive-discogs-effnet-1.onnx", 0),
@@ -122,44 +122,17 @@ EXPECTED_IO: dict[str, dict[str, list[tuple[str, list]]]] = {
 # ---------------------------------------------------------------------------
 
 
-def _semantic_param(field: str):
-    """Wrap each parametrize case so we can attach an xfail marker to
-    individual fields without losing per-case test IDs.
-
-    ``instrumentalness`` is xfail(strict=True) until #99 lands: the test
-    documents the bug, runs in CI as expected-fail, and when the column
-    index is corrected (col 1 → col 0) the test will flip to XPASS,
-    which strict=True turns into a CI failure — forcing someone to
-    remove this xfail marker. That makes the marker self-cleaning.
-    """
-    head = ANALYZER_FIELD_TO_HEAD[field]
-    if field == "instrumentalness":
-        return pytest.param(
-            field,
-            head,
-            marks=pytest.mark.xfail(
-                strict=True,
-                reason=(
-                    "#99 voice_instrumental column inversion. Code at "
-                    "analysis_worker.py:1144 reads col 1 = 'voice' and "
-                    "stores it under the field name 'instrumentalness'. "
-                    "Fix: change the col index to 0 in BOTH analysis_worker "
-                    "and gpu_inference, bump ANALYSIS_VERSION, rescan."
-                ),
-            ),
-            id=field,
-        )
-    return pytest.param(field, head, id=field)
-
-
-@pytest.mark.parametrize("field,head_col", [_semantic_param(f) for f in ANALYZER_FIELD_TO_HEAD])
+@pytest.mark.parametrize(
+    "field,head_col",
+    [pytest.param(f, ANALYZER_FIELD_TO_HEAD[f], id=f) for f in ANALYZER_FIELD_TO_HEAD],
+)
 def test_field_reads_semantically_correct_column(field, head_col):
     """For each analyser field, the column index the code reads must
     correspond to the class the field name implies.
 
-    This is the test that fails today on #99: ``instrumentalness`` reads
-    col 1 = ``voice``, but the field name semantically is ``instrumental``.
-    Fixing #99 (col 1 → col 0) makes this pass.
+    Catches the v2.5 mood-column inversion shape and #99's
+    ``instrumentalness`` (= voice probability) inversion. Re-introducing
+    either would fail this assertion.
     """
     model_file, col = head_col
     classes = MTG_CLASSES[model_file]


### PR DESCRIPTION
## Summary

- Flip the `voice_instrumental` head column read from `1` → `0` in both `analysis_worker._extract_ml` and `gpu_inference.infer_from_patches`. The MTG metadata pins the head's classes as `['instrumental', 'voice']`, so col 0 is the field's named class.
- Bump `ANALYSIS_VERSION` `2.6` → `2.7` so the library rescans every track under the corrected pipeline.
- Drop the `xfail(strict=True)` wrapper in `tests/test_onnx_contracts.py` — the test now passes as a regular regression assertion.

Fixes #99. Issue was auto-closed by #100, which only added the testing infrastructure that catches this class of bug; the underlying column-index fix is in this PR.

## Why this matters

`instrumentalness` was inverted across the entire library: pure-speech tracks scored ~0.89 instrumental, vocal-heavy pop scored ~0.78 instrumental. `taste_profile.py` priors (`mean: 0.15, std: 0.18` — Spotify-shape) were the opposite of what the column actually stored, so the LightGBM ranker had been training on an inverted signal. Same shape as the v2.5 mood column inversion fixed in [c67f235](https://github.com/Sxx7/GrooveIQ/commit/c67f235).

## Test plan

- [x] `python3 -c "..."` semantic-class contract check by hand against the MTG class lists — all 7 analyzer fields now align with their named class.
- [x] `python3 -m ast` parse-check on the modified test module.
- [ ] Reviewer / CI: `pytest tests/test_onnx_contracts.py -v` — the previously `xfailed` `instrumentalness` case should now pass as a regular `OK`.
- [ ] After merge + redeploy + rescan:
  - On a sample of pure-speech tracks (interviews, voice-overs), `instrumentalness < 0.3`.
  - On pure-instrumental tracks (classical solo, ambient), `instrumentalness > 0.6`.
  - Library-wide `AVG(instrumentalness)` shifts ~0.68 → ~0.32.
  - Layer-3 `instrumentalness_avg_below_voice_majority` invariant in `analysis_health.py` flips error → ok.

## Migration notes

Same shape as #88: the rescan is multi-day on a 100k-track library. Until it completes, mixed v2.6/v2.7 `instrumentalness` values live side by side, but each track's value is independently correct or independently inverted, so consumers don't need to special-case the migration window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)